### PR TITLE
fix: prevent duplicate editor hint

### DIFF
--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -99,19 +99,36 @@ class _MainScreenState extends State<MainScreen> {
           child: Column(
             children: [
               Expanded(
-                child: TextField(
-                  controller: _controller,
-                  onChanged: (text) => _onTextChanged(text, settings),
-                  maxLines: null,
-                  expands: true,
-                  textAlignVertical: TextAlignVertical.top,
-                  autofocus: true,
-                  style: _textStyle(settings).copyWith(color: colors.text),
-                  decoration: InputDecoration(
-                    border: InputBorder.none,
-                    hintText: 'Start typing\u2026',
-                    hintStyle: _textStyle(settings).copyWith(color: colors.textSecondary),
-                  ),
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    Positioned.fill(
+                      child: Semantics(
+                        label: 'Start typing',
+                        child: TextField(
+                          controller: _controller,
+                          onChanged: (text) => _onTextChanged(text, settings),
+                          maxLines: null,
+                          expands: true,
+                          textAlignVertical: TextAlignVertical.top,
+                          autofocus: true,
+                          style: _textStyle(settings).copyWith(color: colors.text),
+                          decoration: const InputDecoration(border: InputBorder.none),
+                        ),
+                      ),
+                    ),
+                    ValueListenableBuilder<int>(
+                      valueListenable: _charCount,
+                      builder: (_, count, _) => count == 0
+                          ? ExcludeSemantics(
+                              child: Text(
+                                'Start typing\u2026',
+                                style: _textStyle(settings).copyWith(color: colors.textSecondary),
+                              ),
+                            )
+                          : const SizedBox.shrink(),
+                    ),
+                  ],
                 ),
               ),
               Align(

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,7 +1,49 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:provider/provider.dart';
+import 'package:rolling_text/models/app_settings.dart';
+import 'package:rolling_text/screens/main_screen.dart';
+import 'package:rolling_text/services/preferences_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  test('placeholder', () {
-    expect(true, isTrue);
+  testWidgets('editor renders one app-owned hint until text is entered', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    PackageInfo.setMockInitialValues(
+      appName: 'Rolling Text',
+      packageName: 'io.rollingtext.rolling_text',
+      version: '0.4.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+    final preferences = await SharedPreferences.getInstance();
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => AppSettings(),
+        child: MaterialApp(
+          home: MainScreen(prefsService: PreferencesService(preferences)),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Start typing\u2026'), findsOneWidget);
+    final editor = tester.widget<TextField>(find.byType(TextField).first);
+    expect(editor.decoration?.hintText, isNull);
+    expect(tester.getSize(find.byType(TextField).first).width, greaterThan(700));
+    expect(
+      tester.getTopLeft(find.text('Start typing\u2026')),
+      tester.getTopLeft(find.byType(TextField).first),
+    );
+
+    await tester.enterText(find.byType(TextField).first, 'Hello');
+    await tester.pump();
+
+    expect(find.text('Start typing\u2026'), findsNothing);
+    expect(tester.getSize(find.byType(TextField).first).width, greaterThan(700));
   });
 }


### PR DESCRIPTION
## Summary

- render the empty-editor hint outside `InputDecoration` so Flutter Web does not create a second native placeholder
- keep the editor stack expanded so the text field remains full width
- replace the placeholder widget test with regression coverage for hint count, position, visibility, and editor width

## Validation

- `flutter analyze`
- `flutter test`
- `flutter build web`
- manual Flutter Web verification

Closes #13