### PR TITLE
a11y: make the settings sheets usable from the keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Type: "Hello World" -> "ello World" ('H' removed automatically)
 
 - **Configurable character limit** - Set anywhere from 1 to 1,000,000 characters
 - **Themes** - Light, Dark, and Sepia
-- **Font picker** - Choose from 20 curated Google Fonts or System Default
+- **Font picker** - Choose from 20 curated Google Fonts or System Default. Uncached fonts require an internet connection on first use.
 - **Adjustable font size** - 6pt to 144pt via slider, with custom sizes up to 999pt
 - **Settings persistence** - Character limit, theme, font, and font size are saved between sessions. Text is never saved.
 - **Unicode and emoji support** - Handles multi-byte characters correctly

--- a/README.md
+++ b/README.md
@@ -39,12 +39,15 @@ Type: "Hello Worl" -> 10 chars, at limit
 Type: "Hello World" -> "ello World" ('H' removed automatically)
 ```
 
+Lowering the limit below what you have already written removes the oldest characters immediately, without asking. Like everything else in Rolling Text, that text is gone rather than recoverable.
+
 ## Features
 
 - **Configurable character limit** - Set anywhere from 1 to 1,000,000 characters
 - **Themes** - Light, Dark, and Sepia
-- **Font picker** - Choose from 20 curated Google Fonts or System Default. Uncached fonts require an internet connection on first use.
-- **Adjustable font size** - 6pt to 144pt via slider, with custom sizes up to 999pt
+- **Font picker** - Choose from 20 curated Google Fonts, or Source Code Pro as the default. Uncached fonts require an internet connection on first use.
+- **Adjustable font size** - Type any size from 6pt to 999pt, or drag the slider for 6pt to 144pt
+- **Keyboard operation** - Every settings sheet works without a mouse: arrow keys move between themes and fonts, Enter applies, Escape closes, and arrow or page keys scroll the About text. Focus returns to the editor when a sheet closes.
 - **Settings persistence** - Character limit, theme, font, and font size are saved between sessions. Text is never saved.
 - **Unicode and emoji support** - Handles multi-byte characters correctly
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Google Fonts downloads uncached font files at runtime. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="rolling_text"
         android:name="${applicationName}"

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -282,45 +282,20 @@ class _MainScreenState extends State<MainScreen> {
         colors: colorsFor(settings.theme),
       ),
     );
-    if (newLimit != null) await _applyNewLimit(newLimit, settings);
+    if (newLimit != null) _applyNewLimit(newLimit, settings);
     await _restoreEditorFocus();
   }
 
-  Future<void> _applyNewLimit(int newLimit, AppSettings settings) async {
-    final currentCount = _controller.text.runes.length;
-
-    if (newLimit < currentCount) {
-      final charsToRemove = currentCount - newLimit;
-      showDialog(
-        context: context,
-        builder: (ctx) => AlertDialog(
-          title: const Text('Warning'),
-          content: Text(
-            'This will remove $charsToRemove '
-            '${charsToRemove == 1 ? "character" : "characters"} '
-            'from the beginning of your text. Continue?',
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx),
-              child: const Text('No'),
-            ),
-            TextButton(
-              onPressed: () {
-                Navigator.pop(ctx);
-                settings.setMaxChars(newLimit);
-                widget.prefsService.saveMaxChars(newLimit);
-                _onTextChanged(_controller.text, settings);
-              },
-              child: const Text('Yes'),
-            ),
-          ],
-        ),
-      );
-    } else {
-      settings.setMaxChars(newLimit);
-      widget.prefsService.saveMaxChars(newLimit);
-    }
+  /// Applies a new limit, shortening the text if it no longer fits.
+  ///
+  /// A lower limit takes effect without confirmation: this editor exists to make
+  /// text disappear, so asking permission to shorten it works against the point.
+  /// _onTextChanged truncates when the text is over the limit and does nothing
+  /// when it is not, so one call covers both cases.
+  void _applyNewLimit(int newLimit, AppSettings settings) {
+    settings.setMaxChars(newLimit);
+    widget.prefsService.saveMaxChars(newLimit);
+    _onTextChanged(_controller.text, settings);
   }
 
   Future<void> _showThemeDialog(BuildContext context, AppSettings settings) async {

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -439,12 +439,16 @@ class _MainScreenState extends State<MainScreen> {
     BuildContext context,
     AppSettings settings,
   ) async {
-    await _showSheet<void>(
+    // The sheet previews sizes live, so a dismissal has to undo the preview.
+    // Only Apply (and the Enter that stands in for it) pops true.
+    final originalSize = settings.fontSize;
+    final applied = await _showSheet<bool>(
       builder: (ctx) => _FontSizeSheet(
         settings: settings,
         colors: colorsFor(settings.theme),
       ),
     );
+    if (applied != true) settings.setFontSize(originalSize);
     widget.prefsService.saveFontSize(settings.fontSize);
     await _restoreEditorFocus();
   }
@@ -455,25 +459,32 @@ class _MainScreenState extends State<MainScreen> {
 
     await _showSheet<void>(
       isScrollControlled: true,
-      builder: (ctx) => Shortcuts(
-        // Bare arrows map to focus traversal by default, not scrolling. Sending
-        // them to ScrollIntent reuses Flutter's own scrolling, so this reading
-        // sheet responds to arrows as well as the PageUp/PageDown that Flutter
-        // already binds. No scroll maths of our own.
-        shortcuts: const <ShortcutActivator, Intent>{
-          SingleActivator(LogicalKeyboardKey.arrowDown): ScrollIntent(
-            direction: AxisDirection.down,
-          ),
-          SingleActivator(LogicalKeyboardKey.arrowUp): ScrollIntent(
-            direction: AxisDirection.up,
-          ),
-        },
-        child: DraggableScrollableSheet(
-          initialChildSize: 0.85,
-          minChildSize: 0.4,
-          maxChildSize: 0.95,
-          expand: false,
-          builder: (_, scrollController) => Column(
+      builder: (ctx) => DraggableScrollableSheet(
+        initialChildSize: 0.85,
+        minChildSize: 0.4,
+        maxChildSize: 0.95,
+        expand: false,
+        builder: (_, scrollController) => CallbackShortcuts(
+          // Flutter's own ScrollAction resolves its target by walking UP from
+          // the focused node, so arrows only scroll while something inside the
+          // list holds focus. This list is lazy: an anchor placed in it is
+          // unmounted once scrolled past the cache extent, and the arrows then
+          // die partway down while the mouse wheel keeps working. Driving the
+          // controller costs a little arithmetic but never depends on where
+          // focus sits. The Focus below exists only so key events arrive.
+          bindings: <ShortcutActivator, VoidCallback>{
+            const SingleActivator(LogicalKeyboardKey.arrowDown):
+                () => _scrollAbout(scrollController, _aboutArrowStep),
+            const SingleActivator(LogicalKeyboardKey.arrowUp):
+                () => _scrollAbout(scrollController, -_aboutArrowStep),
+            const SingleActivator(LogicalKeyboardKey.pageDown):
+                () => _scrollAbout(scrollController, _aboutPageStep(scrollController)),
+            const SingleActivator(LogicalKeyboardKey.pageUp):
+                () => _scrollAbout(scrollController, -_aboutPageStep(scrollController)),
+          },
+          child: Focus(
+            autofocus: true,
+            child: Column(
           children: [
             Padding(
               padding: const EdgeInsets.fromLTRB(24, 16, 24, 8),
@@ -501,11 +512,6 @@ class _MainScreenState extends State<MainScreen> {
                 controller: scrollController,
                 padding: const EdgeInsets.all(24),
                 children: [
-                  // ScrollAction finds its Scrollable by looking UP from the
-                  // focused node, so this anchor has to live inside the list. A
-                  // Focus wrapped around the scrollable instead compiles, runs,
-                  // and silently never scrolls.
-                  const Focus(autofocus: true, child: SizedBox.shrink()),
                   _AboutBodyText(
                     'We all carry thoughts we wish we didn\'t. The worries that '
                     'keep us up at night. The harsh things we say to ourselves. '
@@ -609,10 +615,33 @@ class _MainScreenState extends State<MainScreen> {
             ),
             ],
           ),
+          ),
         ),
       ),
     );
     await _restoreEditorFocus();
+  }
+
+  /// One arrow press worth of About-sheet scrolling, in logical pixels.
+  static const double _aboutArrowStep = 80;
+
+  /// One page press worth, scaled to whatever the sheet is currently showing so
+  /// it always outruns an arrow press.
+  double _aboutPageStep(ScrollController controller) =>
+      controller.hasClients ? controller.position.viewportDimension * 0.8 : 0;
+
+  /// Scrolls the About sheet by [delta], clamped to the content.
+  void _scrollAbout(ScrollController controller, double delta) {
+    if (!controller.hasClients) return;
+    final position = controller.position;
+    controller.animateTo(
+      (position.pixels + delta).clamp(
+        position.minScrollExtent,
+        position.maxScrollExtent,
+      ),
+      duration: const Duration(milliseconds: 120),
+      curve: Curves.easeOut,
+    );
   }
 }
 
@@ -648,6 +677,7 @@ class _NumericSheet extends StatefulWidget {
 class _NumericSheetState extends State<_NumericSheet> {
   late final TextEditingController _controller;
   final FocusNode _focusNode = FocusNode();
+  String? _error;
 
   @override
   void initState() {
@@ -672,30 +702,18 @@ class _NumericSheetState extends State<_NumericSheet> {
     );
   }
 
-  Future<void> _apply() async {
+  void _apply() {
     final value = int.tryParse(_controller.text);
     if (value == null || value < widget.minValue || value > widget.maxValue) {
-      await showDialog<void>(
-        context: context,
-        builder: (ctx) => AlertDialog(
-          title: const Text('Invalid Input'),
-          content: Text(widget.errorMessage),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx),
-              child: const Text('OK'),
-            ),
-          ],
-        ),
-      );
       // The sheet deliberately stays open: closing it would discard the value
-      // the user has just been asked to correct.
-      if (!mounted) return;
+      // the user has just been asked to correct. The message is inline rather
+      // than a dialog so it matches the Font Size sheet and costs no keypress
+      // to dismiss.
+      setState(() => _error = widget.errorMessage);
       _focusNode.requestFocus();
       _selectAll();
       return;
     }
-    if (!mounted) return;
     Navigator.pop(context, value);
   }
 
@@ -735,11 +753,15 @@ class _NumericSheetState extends State<_NumericSheet> {
             inputFormatters: [FilteringTextInputFormatter.digitsOnly],
             autofocus: true,
             textInputAction: TextInputAction.done,
+            onChanged: (_) {
+              if (_error != null) setState(() => _error = null);
+            },
             onSubmitted: (_) => _apply(),
             textAlign: TextAlign.center,
             style: const TextStyle(fontSize: 18),
             decoration: InputDecoration(
               hintText: widget.hintText,
+              errorText: _error,
               filled: true,
               fillColor: colors.buttonBackground,
               border: OutlineInputBorder(
@@ -789,6 +811,12 @@ class _FontSizeSheetState extends State<_FontSizeSheet> {
   final FocusNode _focusNode = FocusNode();
   String? _error;
 
+  /// One Enter can arrive twice -- once as a raw key event through the
+  /// sheet-level binding, once as a platform text input action through
+  /// onSubmitted. See framework_assumptions_test.dart. Without this the second
+  /// pop would dismiss whatever route is behind the sheet.
+  bool _closing = false;
+
   @override
   void initState() {
     super.initState();
@@ -830,16 +858,20 @@ class _FontSizeSheetState extends State<_FontSizeSheet> {
     }
   }
 
-  void _onFieldSubmitted(String text) {
-    final value = int.tryParse(text);
+  /// Commits the sheet. Reachable from Apply, from the field's own Enter, and
+  /// from the sheet-level Enter binding (which is how the slider commits).
+  void _apply() {
+    if (_closing) return;
+    final value = int.tryParse(_controller.text);
     if (value == null || value < 6 || value > 999) {
       setState(() => _error = 'Enter a size between 6 and 999 pt');
       _focusNode.requestFocus();
       _selectAll();
       return;
     }
-    // The value was already applied live by _onFieldChanged.
-    Navigator.pop(context);
+    // The value was already applied live by _onFieldChanged or _onSliderChanged.
+    _closing = true;
+    Navigator.pop(context, true);
   }
 
   void _onSliderChanged(double value) {
@@ -856,7 +888,15 @@ class _FontSizeSheetState extends State<_FontSizeSheet> {
   @override
   Widget build(BuildContext context) {
     final colors = widget.colors;
-    return Padding(
+    return CallbackShortcuts(
+      // The slider owns focus after a drag and ignores Enter, so without a
+      // sheet-level binding there is no way to commit from the keyboard once
+      // you have touched it.
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.enter): _apply,
+        const SingleActivator(LogicalKeyboardKey.numpadEnter): _apply,
+      },
+      child: Padding(
       padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -887,7 +927,7 @@ class _FontSizeSheetState extends State<_FontSizeSheet> {
             autofocus: true,
             textInputAction: TextInputAction.done,
             onChanged: _onFieldChanged,
-            onSubmitted: _onFieldSubmitted,
+            onSubmitted: (_) => _apply(),
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 24,
@@ -921,7 +961,20 @@ class _FontSizeSheetState extends State<_FontSizeSheet> {
               Text('144pt', style: TextStyle(color: colors.textSecondary, fontSize: 12)),
             ],
           ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              const SizedBox(width: 8),
+              FilledButton(onPressed: _apply, child: const Text('Apply')),
+            ],
+          ),
         ],
+      ),
       ),
     );
   }

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -467,12 +467,25 @@ class _MainScreenState extends State<MainScreen> {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
-      builder: (ctx) => DraggableScrollableSheet(
-        initialChildSize: 0.85,
-        minChildSize: 0.4,
-        maxChildSize: 0.95,
-        expand: false,
-        builder: (_, scrollController) => Column(
+      builder: (ctx) => Shortcuts(
+        // Bare arrows map to focus traversal by default, not scrolling. Sending
+        // them to ScrollIntent reuses Flutter's own scrolling, so this reading
+        // sheet responds to arrows as well as the PageUp/PageDown that Flutter
+        // already binds. No scroll maths of our own.
+        shortcuts: const <ShortcutActivator, Intent>{
+          SingleActivator(LogicalKeyboardKey.arrowDown): ScrollIntent(
+            direction: AxisDirection.down,
+          ),
+          SingleActivator(LogicalKeyboardKey.arrowUp): ScrollIntent(
+            direction: AxisDirection.up,
+          ),
+        },
+        child: DraggableScrollableSheet(
+          initialChildSize: 0.85,
+          minChildSize: 0.4,
+          maxChildSize: 0.95,
+          expand: false,
+          builder: (_, scrollController) => Column(
           children: [
             Padding(
               padding: const EdgeInsets.fromLTRB(24, 16, 24, 8),
@@ -500,6 +513,11 @@ class _MainScreenState extends State<MainScreen> {
                 controller: scrollController,
                 padding: const EdgeInsets.all(24),
                 children: [
+                  // ScrollAction finds its Scrollable by looking UP from the
+                  // focused node, so this anchor has to live inside the list. A
+                  // Focus wrapped around the scrollable instead compiles, runs,
+                  // and silently never scrolls.
+                  const Focus(autofocus: true, child: SizedBox.shrink()),
                   _AboutBodyText(
                     'We all carry thoughts we wish we didn\'t. The worries that '
                     'keep us up at night. The harsh things we say to ourselves. '
@@ -601,7 +619,8 @@ class _MainScreenState extends State<MainScreen> {
                 ],
               ),
             ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -439,100 +439,13 @@ class _MainScreenState extends State<MainScreen> {
     BuildContext context,
     AppSettings settings,
   ) async {
-    double currentSize = settings.fontSize;
-
     await _showSheet<void>(
-      builder: (ctx) {
-        final colors = colorsFor(settings.theme);
-        return StatefulBuilder(
-          builder: (ctx, setSheetState) => Padding(
-            padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Row(
-                  children: [
-                    Text(
-                      'Font Size',
-                      style: TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
-                        color: colors.text,
-                      ),
-                    ),
-                    const Spacer(),
-                    IconButton(
-                      icon: const Icon(Icons.close),
-                      onPressed: () => Navigator.pop(ctx),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  '${currentSize.round()}pt',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: colors.text,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Slider(
-                  value: currentSize.clamp(6, 144),
-                  min: 6,
-                  max: 144,
-                  divisions: 138,
-                  label: '${currentSize.round()}pt',
-                  onChanged: (value) {
-                    setSheetState(() => currentSize = value.roundToDouble());
-                    settings.setFontSize(currentSize);
-                  },
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text('6pt', style: TextStyle(color: colors.textSecondary, fontSize: 12)),
-                    Text('144pt', style: TextStyle(color: colors.textSecondary, fontSize: 12)),
-                  ],
-                ),
-                const SizedBox(height: 12),
-                TextButton(
-                  onPressed: () {
-                    Navigator.pop(ctx);
-                    _showCustomFontSizeDialog(context, settings);
-                  },
-                  child: const Text('Enter custom size\u2026'),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-    widget.prefsService.saveFontSize(settings.fontSize);
-    await _restoreEditorFocus();
-  }
-
-  Future<void> _showCustomFontSizeDialog(
-    BuildContext context,
-    AppSettings settings,
-  ) async {
-    final newSize = await _showSheet<int>(
-      isScrollControlled: true,
-      builder: (ctx) => _NumericSheet(
-        title: 'Custom Font Size',
-        hintText: '6 – 999',
-        initialValue: settings.fontSize.toInt(),
-        minValue: 6,
-        maxValue: 999,
-        errorMessage: 'Please enter a size between 6 and 999 pt',
+      builder: (ctx) => _FontSizeSheet(
+        settings: settings,
         colors: colorsFor(settings.theme),
       ),
     );
-    if (newSize != null) {
-      settings.setFontSize(newSize.toDouble());
-      widget.prefsService.saveFontSize(newSize.toDouble());
-    }
+    widget.prefsService.saveFontSize(settings.fontSize);
     await _restoreEditorFocus();
   }
 
@@ -845,6 +758,167 @@ class _NumericSheetState extends State<_NumericSheet> {
               ),
               const SizedBox(width: 8),
               FilledButton(onPressed: _apply, child: const Text('Apply')),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The Font Size sheet: a numeric field and a slider that both edit the same
+/// value live, kept in sync with each other.
+///
+/// The field is autofocused with its value preselected, so the sheet is
+/// typeable the instant it opens -- no button, no second sheet to reach a
+/// keyboard. Field precedes the slider in the widget tree, so a single Tab
+/// from the field reaches the slider.
+class _FontSizeSheet extends StatefulWidget {
+  final AppSettings settings;
+  final AppColors colors;
+
+  const _FontSizeSheet({required this.settings, required this.colors});
+
+  @override
+  State<_FontSizeSheet> createState() => _FontSizeSheetState();
+}
+
+class _FontSizeSheetState extends State<_FontSizeSheet> {
+  late double _size;
+  late final TextEditingController _controller;
+  final FocusNode _focusNode = FocusNode();
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _size = widget.settings.fontSize;
+    _controller = TextEditingController(text: '${_size.round()}');
+    _selectAll();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  /// Selects the whole value so the next keystroke replaces it rather than
+  /// appending to it.
+  void _selectAll() {
+    _controller.selection = TextSelection(
+      baseOffset: 0,
+      extentOffset: _controller.text.length,
+    );
+  }
+
+  // Applies a valid value immediately, matching the slider. An invalid or
+  // incomplete value (e.g. "" while backspacing) is left un-applied and
+  // silent -- flashing an error on every keystroke would fight the user
+  // typing a number one digit at a time.
+  void _onFieldChanged(String text) {
+    final value = int.tryParse(text);
+    if (value != null && value >= 6 && value <= 999) {
+      setState(() {
+        _error = null;
+        _size = value.toDouble();
+      });
+      widget.settings.setFontSize(_size);
+    } else if (_error != null) {
+      setState(() => _error = null);
+    }
+  }
+
+  void _onFieldSubmitted(String text) {
+    final value = int.tryParse(text);
+    if (value == null || value < 6 || value > 999) {
+      setState(() => _error = 'Enter a size between 6 and 999 pt');
+      _focusNode.requestFocus();
+      _selectAll();
+      return;
+    }
+    // The value was already applied live by _onFieldChanged.
+    Navigator.pop(context);
+  }
+
+  void _onSliderChanged(double value) {
+    final rounded = value.roundToDouble();
+    setState(() {
+      _error = null;
+      _size = rounded;
+      _controller.text = '${rounded.round()}';
+      _selectAll();
+    });
+    widget.settings.setFontSize(rounded);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = widget.colors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Text(
+                'Font Size',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: colors.text,
+                ),
+              ),
+              const Spacer(),
+              IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () => Navigator.pop(context),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _controller,
+            focusNode: _focusNode,
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            autofocus: true,
+            textInputAction: TextInputAction.done,
+            onChanged: _onFieldChanged,
+            onSubmitted: _onFieldSubmitted,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+              color: colors.text,
+            ),
+            decoration: InputDecoration(
+              suffixText: 'pt',
+              errorText: _error,
+              filled: true,
+              fillColor: colors.buttonBackground,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide.none,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Slider(
+            value: _size.clamp(6, 144),
+            min: 6,
+            max: 144,
+            divisions: 138,
+            label: '${_size.round()}pt',
+            onChanged: _onSliderChanged,
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('6pt', style: TextStyle(color: colors.textSecondary, fontSize: 12)),
+              Text('144pt', style: TextStyle(color: colors.textSecondary, fontSize: 12)),
             ],
           ),
         ],

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -424,32 +424,14 @@ class _MainScreenState extends State<MainScreen> {
               ),
               const Divider(height: 1),
               Expanded(
-                child: ListView(
-                  controller: scrollController,
-                  children: [
-                    _FontTile(
-                      label: 'Source Code Pro (Default)',
-                      style: GoogleFonts.getFont('Source Code Pro'),
-                      selected: settings.fontFamily == null,
-                      onTap: () {
-                        settings.setFontFamily(null);
-                        widget.prefsService.saveFontFamily(null);
-                        Navigator.pop(ctx);
-                      },
-                    ),
-                    ...availableFonts.map((family) {
-                      return _FontTile(
-                        label: family,
-                        style: GoogleFonts.getFont(family),
-                        selected: settings.fontFamily == family,
-                        onTap: () {
-                          settings.setFontFamily(family);
-                          widget.prefsService.saveFontFamily(family);
-                          Navigator.pop(ctx);
-                        },
-                      );
-                    }),
-                  ],
+                child: _FontList(
+                  scrollController: scrollController,
+                  selectedFamily: settings.fontFamily,
+                  onSelected: (family) {
+                    settings.setFontFamily(family);
+                    widget.prefsService.saveFontFamily(family);
+                    Navigator.pop(ctx);
+                  },
                 ),
               ),
             ],
@@ -793,6 +775,73 @@ class _MainScreenState extends State<MainScreen> {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// The scrolling list of fonts.
+///
+/// Stateful so it can reveal the active font when the sheet opens. Rows past
+/// the viewport are built lazily, and a row that is never built can neither be
+/// seen nor take keyboard focus, so a font near the end of the list would
+/// otherwise be invisible and unreachable when its own picker opens.
+class _FontList extends StatefulWidget {
+  final ScrollController scrollController;
+  final String? selectedFamily;
+  final ValueChanged<String?> onSelected;
+
+  const _FontList({
+    required this.scrollController,
+    required this.selectedFamily,
+    required this.onSelected,
+  });
+
+  @override
+  State<_FontList> createState() => _FontListState();
+}
+
+class _FontListState extends State<_FontList> {
+  /// Enforced on the ListView below, so the offset arithmetic in
+  /// [_revealSelection] is exact by construction rather than an assumption
+  /// about how tall a ListTile happens to render.
+  static const double _tileExtent = 56;
+
+  static const List<String?> _options = [null, ...availableFonts];
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _revealSelection());
+  }
+
+  void _revealSelection() {
+    final index = _options.indexOf(widget.selectedFamily);
+    if (!mounted || index <= 0) return;
+    final controller = widget.scrollController;
+    if (!controller.hasClients) return;
+    controller.jumpTo(
+      (index * _tileExtent).clamp(
+        controller.position.minScrollExtent,
+        controller.position.maxScrollExtent,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      controller: widget.scrollController,
+      itemExtent: _tileExtent,
+      itemCount: _options.length,
+      itemBuilder: (context, index) {
+        final family = _options[index];
+        return _FontTile(
+          label: family ?? 'Source Code Pro (Default)',
+          style: GoogleFonts.getFont(family ?? 'Source Code Pro'),
+          selected: family == widget.selectedFamily,
+          onTap: () => widget.onSelected(family),
+        );
+      },
     );
   }
 }

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -198,12 +198,33 @@ class _MainScreenState extends State<MainScreen> {
   void _showLimitDialog(BuildContext context, AppSettings settings) {
     final inputController =
         TextEditingController(text: '${settings.maxChars}');
+    // Preselect so the first keystroke replaces the current limit rather than
+    // appending to it.
+    inputController.selection = TextSelection(
+      baseOffset: 0,
+      extentOffset: inputController.text.length,
+    );
 
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       builder: (ctx) {
         final colors = colorsFor(settings.theme);
+
+        void applyLimit() {
+          final value = int.tryParse(inputController.text);
+          if (value == null || value < 1 || value > 1000000) {
+            Navigator.pop(ctx);
+            _showErrorDialog(
+              context,
+              'Please enter a number between 1 and 1,000,000',
+            );
+            return;
+          }
+          Navigator.pop(ctx);
+          _applyNewLimit(value, settings);
+        }
+
         return Padding(
           padding: EdgeInsets.fromLTRB(
             24, 16, 24,
@@ -235,6 +256,8 @@ class _MainScreenState extends State<MainScreen> {
                 keyboardType: TextInputType.number,
                 inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                 autofocus: true,
+                textInputAction: TextInputAction.done,
+                onSubmitted: (_) => applyLimit(),
                 textAlign: TextAlign.center,
                 style: const TextStyle(fontSize: 18),
                 decoration: InputDecoration(
@@ -257,17 +280,7 @@ class _MainScreenState extends State<MainScreen> {
                   ),
                   const SizedBox(width: 8),
                   FilledButton(
-                    onPressed: () {
-                      final value = int.tryParse(inputController.text);
-                      if (value == null || value < 1 || value > 1000000) {
-                        Navigator.pop(ctx);
-                        _showErrorDialog(context,
-                            'Please enter a number between 1 and 1,000,000');
-                        return;
-                      }
-                      Navigator.pop(ctx);
-                      _applyNewLimit(value, settings);
-                    },
+                    onPressed: applyLimit,
                     child: const Text('Apply'),
                   ),
                 ],
@@ -521,12 +534,34 @@ class _MainScreenState extends State<MainScreen> {
   void _showCustomFontSizeDialog(BuildContext context, AppSettings settings) {
     final inputController =
         TextEditingController(text: '${settings.fontSize.toInt()}');
+    // Preselect so the first keystroke replaces the current size rather than
+    // appending to it.
+    inputController.selection = TextSelection(
+      baseOffset: 0,
+      extentOffset: inputController.text.length,
+    );
 
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       builder: (ctx) {
         final colors = colorsFor(settings.theme);
+
+        void applyFontSize() {
+          final value = int.tryParse(inputController.text);
+          if (value == null || value < 6 || value > 999) {
+            Navigator.pop(ctx);
+            _showErrorDialog(
+              context,
+              'Please enter a size between 6 and 999 pt',
+            );
+            return;
+          }
+          settings.setFontSize(value.toDouble());
+          widget.prefsService.saveFontSize(value.toDouble());
+          Navigator.pop(ctx);
+        }
+
         return Padding(
           padding: EdgeInsets.fromLTRB(
             24, 16, 24,
@@ -558,6 +593,8 @@ class _MainScreenState extends State<MainScreen> {
                 keyboardType: TextInputType.number,
                 inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                 autofocus: true,
+                textInputAction: TextInputAction.done,
+                onSubmitted: (_) => applyFontSize(),
                 textAlign: TextAlign.center,
                 style: const TextStyle(fontSize: 18),
                 decoration: InputDecoration(
@@ -580,18 +617,7 @@ class _MainScreenState extends State<MainScreen> {
                   ),
                   const SizedBox(width: 8),
                   FilledButton(
-                    onPressed: () {
-                      final value = int.tryParse(inputController.text);
-                      if (value == null || value < 6 || value > 999) {
-                        Navigator.pop(ctx);
-                        _showErrorDialog(
-                            context, 'Please enter a size between 6 and 999 pt');
-                        return;
-                      }
-                      settings.setFontSize(value.toDouble());
-                      widget.prefsService.saveFontSize(value.toDouble());
-                      Navigator.pop(ctx);
-                    },
+                    onPressed: applyFontSize,
                     child: const Text('Apply'),
                   ),
                 ],

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -195,101 +195,21 @@ class _MainScreenState extends State<MainScreen> {
     );
   }
 
-  void _showLimitDialog(BuildContext context, AppSettings settings) {
-    final inputController =
-        TextEditingController(text: '${settings.maxChars}');
-    // Preselect so the first keystroke replaces the current limit rather than
-    // appending to it.
-    inputController.selection = TextSelection(
-      baseOffset: 0,
-      extentOffset: inputController.text.length,
-    );
-
-    showModalBottomSheet(
+  Future<void> _showLimitDialog(BuildContext context, AppSettings settings) async {
+    final newLimit = await showModalBottomSheet<int>(
       context: context,
       isScrollControlled: true,
-      builder: (ctx) {
-        final colors = colorsFor(settings.theme);
-
-        void applyLimit() {
-          final value = int.tryParse(inputController.text);
-          if (value == null || value < 1 || value > 1000000) {
-            Navigator.pop(ctx);
-            _showErrorDialog(
-              context,
-              'Please enter a number between 1 and 1,000,000',
-            );
-            return;
-          }
-          Navigator.pop(ctx);
-          _applyNewLimit(value, settings);
-        }
-
-        return Padding(
-          padding: EdgeInsets.fromLTRB(
-            24, 16, 24,
-            MediaQuery.of(ctx).viewInsets.bottom + 32,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Row(
-                children: [
-                  Text(
-                    'Character Limit',
-                    style: TextStyle(
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                      color: colors.text,
-                    ),
-                  ),
-                  const Spacer(),
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    onPressed: () => Navigator.pop(ctx),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: inputController,
-                keyboardType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                autofocus: true,
-                textInputAction: TextInputAction.done,
-                onSubmitted: (_) => applyLimit(),
-                textAlign: TextAlign.center,
-                style: const TextStyle(fontSize: 18),
-                decoration: InputDecoration(
-                  hintText: '1 \u2013 1,000,000',
-                  filled: true,
-                  fillColor: colors.buttonBackground,
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide.none,
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  TextButton(
-                    onPressed: () => Navigator.pop(ctx),
-                    child: const Text('Cancel'),
-                  ),
-                  const SizedBox(width: 8),
-                  FilledButton(
-                    onPressed: applyLimit,
-                    child: const Text('Apply'),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        );
-      },
+      builder: (ctx) => _NumericSheet(
+        title: 'Character Limit',
+        hintText: '1 – 1,000,000',
+        initialValue: settings.maxChars,
+        minValue: 1,
+        maxValue: 1000000,
+        errorMessage: 'Please enter a number between 1 and 1,000,000',
+        colors: colorsFor(settings.theme),
+      ),
     );
+    if (newLimit != null) _applyNewLimit(newLimit, settings);
   }
 
   void _applyNewLimit(int newLimit, AppSettings settings) {
@@ -517,102 +437,27 @@ class _MainScreenState extends State<MainScreen> {
     });
   }
 
-  void _showCustomFontSizeDialog(BuildContext context, AppSettings settings) {
-    final inputController =
-        TextEditingController(text: '${settings.fontSize.toInt()}');
-    // Preselect so the first keystroke replaces the current size rather than
-    // appending to it.
-    inputController.selection = TextSelection(
-      baseOffset: 0,
-      extentOffset: inputController.text.length,
-    );
-
-    showModalBottomSheet(
+  Future<void> _showCustomFontSizeDialog(
+    BuildContext context,
+    AppSettings settings,
+  ) async {
+    final newSize = await showModalBottomSheet<int>(
       context: context,
       isScrollControlled: true,
-      builder: (ctx) {
-        final colors = colorsFor(settings.theme);
-
-        void applyFontSize() {
-          final value = int.tryParse(inputController.text);
-          if (value == null || value < 6 || value > 999) {
-            Navigator.pop(ctx);
-            _showErrorDialog(
-              context,
-              'Please enter a size between 6 and 999 pt',
-            );
-            return;
-          }
-          settings.setFontSize(value.toDouble());
-          widget.prefsService.saveFontSize(value.toDouble());
-          Navigator.pop(ctx);
-        }
-
-        return Padding(
-          padding: EdgeInsets.fromLTRB(
-            24, 16, 24,
-            MediaQuery.of(ctx).viewInsets.bottom + 32,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Row(
-                children: [
-                  Text(
-                    'Custom Font Size',
-                    style: TextStyle(
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                      color: colors.text,
-                    ),
-                  ),
-                  const Spacer(),
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    onPressed: () => Navigator.pop(ctx),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: inputController,
-                keyboardType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                autofocus: true,
-                textInputAction: TextInputAction.done,
-                onSubmitted: (_) => applyFontSize(),
-                textAlign: TextAlign.center,
-                style: const TextStyle(fontSize: 18),
-                decoration: InputDecoration(
-                  hintText: '6 \u2013 999',
-                  filled: true,
-                  fillColor: colors.buttonBackground,
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide.none,
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  TextButton(
-                    onPressed: () => Navigator.pop(ctx),
-                    child: const Text('Cancel'),
-                  ),
-                  const SizedBox(width: 8),
-                  FilledButton(
-                    onPressed: applyFontSize,
-                    child: const Text('Apply'),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        );
-      },
+      builder: (ctx) => _NumericSheet(
+        title: 'Custom Font Size',
+        hintText: '6 – 999',
+        initialValue: settings.fontSize.toInt(),
+        minValue: 6,
+        maxValue: 999,
+        errorMessage: 'Please enter a size between 6 and 999 pt',
+        colors: colorsFor(settings.theme),
+      ),
     );
+    if (newSize != null) {
+      settings.setFontSize(newSize.toDouble());
+      widget.prefsService.saveFontSize(newSize.toDouble());
+    }
   }
 
   void _showAboutSheet(BuildContext context, String version) {
@@ -762,16 +607,151 @@ class _MainScreenState extends State<MainScreen> {
     );
   }
 
-  void _showErrorDialog(BuildContext context, String message) {
-    showDialog(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Invalid Input'),
-        content: Text(message),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: const Text('OK'),
+}
+
+/// A bottom sheet that collects one whole number in a range.
+///
+/// Returns the accepted value via [Navigator.pop], so the caller decides what
+/// to persist and nothing is committed unless the user applies a valid entry.
+/// Stateful so the field's controller and focus node are disposed with the
+/// sheet rather than leaking on every open.
+class _NumericSheet extends StatefulWidget {
+  final String title;
+  final String hintText;
+  final int initialValue;
+  final int minValue;
+  final int maxValue;
+  final String errorMessage;
+  final AppColors colors;
+
+  const _NumericSheet({
+    required this.title,
+    required this.hintText,
+    required this.initialValue,
+    required this.minValue,
+    required this.maxValue,
+    required this.errorMessage,
+    required this.colors,
+  });
+
+  @override
+  State<_NumericSheet> createState() => _NumericSheetState();
+}
+
+class _NumericSheetState extends State<_NumericSheet> {
+  late final TextEditingController _controller;
+  final FocusNode _focusNode = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: '${widget.initialValue}');
+    _selectAll();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  /// Selects the whole value so the next keystroke replaces it rather than
+  /// appending to it.
+  void _selectAll() {
+    _controller.selection = TextSelection(
+      baseOffset: 0,
+      extentOffset: _controller.text.length,
+    );
+  }
+
+  Future<void> _apply() async {
+    final value = int.tryParse(_controller.text);
+    if (value == null || value < widget.minValue || value > widget.maxValue) {
+      await showDialog<void>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Invalid Input'),
+          content: Text(widget.errorMessage),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+      // The sheet deliberately stays open: closing it would discard the value
+      // the user has just been asked to correct.
+      if (!mounted) return;
+      _focusNode.requestFocus();
+      _selectAll();
+      return;
+    }
+    if (!mounted) return;
+    Navigator.pop(context, value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = widget.colors;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        24, 16, 24,
+        MediaQuery.of(context).viewInsets.bottom + 32,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Text(
+                widget.title,
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: colors.text,
+                ),
+              ),
+              const Spacer(),
+              IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () => Navigator.pop(context),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _controller,
+            focusNode: _focusNode,
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            autofocus: true,
+            textInputAction: TextInputAction.done,
+            onSubmitted: (_) => _apply(),
+            textAlign: TextAlign.center,
+            style: const TextStyle(fontSize: 18),
+            decoration: InputDecoration(
+              hintText: widget.hintText,
+              filled: true,
+              fillColor: colors.buttonBackground,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide.none,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              const SizedBox(width: 8),
+              FilledButton(onPressed: _apply, child: const Text('Apply')),
+            ],
           ),
         ],
       ),

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -44,6 +44,7 @@ class MainScreen extends StatefulWidget {
 
 class _MainScreenState extends State<MainScreen> {
   final TextEditingController _controller = TextEditingController();
+  final FocusNode _editorFocusNode = FocusNode();
   final ValueNotifier<int> _charCount = ValueNotifier<int>(0);
   bool _isEnforcing = false;
   String _version = '';
@@ -58,9 +59,73 @@ class _MainScreenState extends State<MainScreen> {
 
   @override
   void dispose() {
+    _editorFocusNode.dispose();
     _controller.dispose();
     _charCount.dispose();
     super.dispose();
+  }
+
+  /// Shows a bottom sheet and waits until it has fully gone away.
+  ///
+  /// showModalBottomSheet returns the route's `popped` future, which completes
+  /// while the sheet is still animating out and before the sheet disposes its
+  /// own focus nodes. Restoring editor focus at that point is silently undone
+  /// by the departing sheet -- observed in Chrome with the numeric sheets,
+  /// which own a text field. Awaiting TransitionRoute.completed instead means
+  /// the sheet is really gone before focus is restored.
+  Future<T?> _showSheet<T>({
+    required WidgetBuilder builder,
+    bool isScrollControlled = false,
+  }) async {
+    final navigator = Navigator.of(context);
+    final localizations = MaterialLocalizations.of(context);
+    final route = ModalBottomSheetRoute<T>(
+      builder: builder,
+      isScrollControlled: isScrollControlled,
+      capturedThemes: InheritedTheme.capture(
+        from: context,
+        to: navigator.context,
+      ),
+      barrierLabel: localizations.scrimLabel,
+      barrierOnTapHint: localizations.scrimOnTapHint(
+        localizations.bottomSheetLabel,
+      ),
+    );
+    final result = await navigator.push(route);
+    await route.completed;
+    return result;
+  }
+
+  /// Returns text input to the editor after a sheet closes.
+  ///
+  /// Flutter restores framework focus on its own when a route pops, but on Web
+  /// that is not enough: the editor's FocusNode reports focus while the browser
+  /// is left with no focused input element, so the next keystroke goes nowhere.
+  /// Verified in Chrome against this build -- the hidden textarea Flutter uses
+  /// for text input is focused on load and unfocused after a sheet is
+  /// dismissed, so a bare requestFocus() would be a no-op. Cycling unfocus,
+  /// then a frame, then refocus forces EditableText to re-establish its input
+  /// connection.
+  ///
+  /// Do not simplify this away on the strength of a green test run: widget
+  /// tests cannot observe browser focus and pass either way. Re-check in a real
+  /// browser instead.
+  Future<void> _restoreEditorFocus() async {
+    if (!mounted) return;
+    _editorFocusNode.unfocus();
+    // endOfFrame schedules a frame if none is pending; addPostFrameCallback
+    // does not, and would strand this when the app is idle.
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) return;
+    _editorFocusNode.requestFocus();
+
+    // The draggable sheets (Font, About) tear down over one more frame than the
+    // plain ones, and that teardown drops the connection just restored above.
+    // Observed in Chrome: without this second pass, dismissing either of those
+    // two with Escape leaves the editor untypeable while the others are fine.
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) return;
+    _editorFocusNode.requestFocus();
   }
 
   void _onTextChanged(String text, AppSettings settings) {
@@ -107,6 +172,7 @@ class _MainScreenState extends State<MainScreen> {
                         label: 'Start typing',
                         child: TextField(
                           controller: _controller,
+                          focusNode: _editorFocusNode,
                           onChanged: (text) => _onTextChanged(text, settings),
                           maxLines: null,
                           expands: true,
@@ -196,8 +262,7 @@ class _MainScreenState extends State<MainScreen> {
   }
 
   Future<void> _showLimitDialog(BuildContext context, AppSettings settings) async {
-    final newLimit = await showModalBottomSheet<int>(
-      context: context,
+    final newLimit = await _showSheet<int>(
       isScrollControlled: true,
       builder: (ctx) => _NumericSheet(
         title: 'Character Limit',
@@ -209,10 +274,11 @@ class _MainScreenState extends State<MainScreen> {
         colors: colorsFor(settings.theme),
       ),
     );
-    if (newLimit != null) _applyNewLimit(newLimit, settings);
+    if (newLimit != null) await _applyNewLimit(newLimit, settings);
+    await _restoreEditorFocus();
   }
 
-  void _applyNewLimit(int newLimit, AppSettings settings) {
+  Future<void> _applyNewLimit(int newLimit, AppSettings settings) async {
     final currentCount = _controller.text.runes.length;
 
     if (newLimit < currentCount) {
@@ -249,9 +315,8 @@ class _MainScreenState extends State<MainScreen> {
     }
   }
 
-  void _showThemeDialog(BuildContext context, AppSettings settings) {
-    showModalBottomSheet(
-      context: context,
+  Future<void> _showThemeDialog(BuildContext context, AppSettings settings) async {
+    await _showSheet<void>(
       builder: (ctx) {
         final colors = colorsFor(settings.theme);
         return Padding(
@@ -307,11 +372,11 @@ class _MainScreenState extends State<MainScreen> {
         );
       },
     );
+    await _restoreEditorFocus();
   }
 
-  void _showFontDialog(BuildContext context, AppSettings settings) {
-    showModalBottomSheet(
-      context: context,
+  Future<void> _showFontDialog(BuildContext context, AppSettings settings) async {
+    await _showSheet<void>(
       isScrollControlled: true,
       builder: (ctx) {
         final colors = colorsFor(settings.theme);
@@ -359,13 +424,16 @@ class _MainScreenState extends State<MainScreen> {
         );
       },
     );
+    await _restoreEditorFocus();
   }
 
-  void _showFontSizeDialog(BuildContext context, AppSettings settings) {
+  Future<void> _showFontSizeDialog(
+    BuildContext context,
+    AppSettings settings,
+  ) async {
     double currentSize = settings.fontSize;
 
-    showModalBottomSheet(
-      context: context,
+    await _showSheet<void>(
       builder: (ctx) {
         final colors = colorsFor(settings.theme);
         return StatefulBuilder(
@@ -432,17 +500,16 @@ class _MainScreenState extends State<MainScreen> {
           ),
         );
       },
-    ).whenComplete(() {
-      widget.prefsService.saveFontSize(settings.fontSize);
-    });
+    );
+    widget.prefsService.saveFontSize(settings.fontSize);
+    await _restoreEditorFocus();
   }
 
   Future<void> _showCustomFontSizeDialog(
     BuildContext context,
     AppSettings settings,
   ) async {
-    final newSize = await showModalBottomSheet<int>(
-      context: context,
+    final newSize = await _showSheet<int>(
       isScrollControlled: true,
       builder: (ctx) => _NumericSheet(
         title: 'Custom Font Size',
@@ -458,14 +525,14 @@ class _MainScreenState extends State<MainScreen> {
       settings.setFontSize(newSize.toDouble());
       widget.prefsService.saveFontSize(newSize.toDouble());
     }
+    await _restoreEditorFocus();
   }
 
-  void _showAboutSheet(BuildContext context, String version) {
+  Future<void> _showAboutSheet(BuildContext context, String version) async {
     final settings = context.read<AppSettings>();
     final colors = colorsFor(settings.theme);
 
-    showModalBottomSheet(
-      context: context,
+    await _showSheet<void>(
       isScrollControlled: true,
       builder: (ctx) => Shortcuts(
         // Bare arrows map to focus traversal by default, not scrolling. Sending
@@ -624,8 +691,8 @@ class _MainScreenState extends State<MainScreen> {
         ),
       ),
     );
+    await _restoreEditorFocus();
   }
-
 }
 
 /// A bottom sheet that collects one whole number in a range.

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -96,21 +97,28 @@ class _MainScreenState extends State<MainScreen> {
     return result;
   }
 
-  /// Returns text input to the editor after a sheet closes.
+  /// Returns text input to the editor after a sheet closes. Web only.
   ///
-  /// Flutter restores framework focus on its own when a route pops, but on Web
-  /// that is not enough: the editor's FocusNode reports focus while the browser
-  /// is left with no focused input element, so the next keystroke goes nowhere.
-  /// Verified in Chrome against this build -- the hidden textarea Flutter uses
-  /// for text input is focused on load and unfocused after a sheet is
-  /// dismissed, so a bare requestFocus() would be a no-op. Cycling unfocus,
-  /// then a frame, then refocus forces EditableText to re-establish its input
-  /// connection.
+  /// Flutter restores framework focus on its own when a route pops, and on
+  /// native platforms that is sufficient -- ModalRoute hands focus back to the
+  /// editor with a live input connection. On Web it is not enough: the editor's
+  /// FocusNode reports focus while the browser is left with no focused input
+  /// element, so the next keystroke goes nowhere. Verified in Chrome against
+  /// this build -- the hidden textarea Flutter uses for text input is focused
+  /// on load and unfocused after a sheet is dismissed, so a bare requestFocus()
+  /// would be a no-op. Cycling unfocus, then a frame, then refocus forces
+  /// EditableText to re-establish its input connection.
   ///
-  /// Do not simplify this away on the strength of a green test run: widget
-  /// tests cannot observe browser focus and pass either way. Re-check in a real
-  /// browser instead.
+  /// The kIsWeb gate is load-bearing, not a micro-optimisation. Running this on
+  /// Android closes and reopens the software keyboard on every sheet dismissal,
+  /// a visible flicker confirmed on a Pixel 8 Pro release build. Do not remove
+  /// the gate to "simplify" the platform split.
+  ///
+  /// Equally, do not delete the body on the strength of a green test run:
+  /// widget tests run on the native platform, where this no-ops, and cannot
+  /// observe browser focus. Re-check in a real browser instead.
   Future<void> _restoreEditorFocus() async {
+    if (!kIsWeb) return;
     if (!mounted) return;
     _editorFocusNode.unfocus();
     // endOfFrame schedules a frame if none is pending; addPostFrameCallback

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -360,6 +360,10 @@ class _MainScreenState extends State<MainScreen> {
               ...AppTheme.values.map((theme) {
                 final themeColors = colorsFor(theme);
                 return ListTile(
+                  // Opening on the active row lets arrow keys navigate from
+                  // where the user already is. Traversal, the focus highlight
+                  // and Enter activation all come from the framework.
+                  autofocus: settings.theme == theme,
                   leading: Container(
                     width: 32,
                     height: 32,
@@ -809,6 +813,9 @@ class _FontTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
+      // Opening on the active row lets arrow keys navigate from where the user
+      // already is.
+      autofocus: selected,
       title: Text(label, style: style),
       trailing: selected ? const Icon(Icons.check) : null,
       selected: selected,

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -327,7 +327,9 @@ class _MainScreenState extends State<MainScreen> {
     await _showSheet<void>(
       builder: (ctx) {
         final colors = colorsFor(settings.theme);
-        return _SheetInitialFocus(
+        return Shortcuts(
+          shortcuts: _rowTraversalShortcuts,
+          child: _SheetInitialFocus(
           builder: (rowFocusNode) => Padding(
           padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
           child: Column(
@@ -380,6 +382,7 @@ class _MainScreenState extends State<MainScreen> {
             ],
           ),
           ),
+          ),
         );
       },
     );
@@ -391,7 +394,9 @@ class _MainScreenState extends State<MainScreen> {
       isScrollControlled: true,
       builder: (ctx) {
         final colors = colorsFor(settings.theme);
-        return DraggableScrollableSheet(
+        return Shortcuts(
+          shortcuts: _rowTraversalShortcuts,
+          child: DraggableScrollableSheet(
           initialChildSize: 0.6,
           minChildSize: 0.3,
           maxChildSize: 0.9,
@@ -431,6 +436,7 @@ class _MainScreenState extends State<MainScreen> {
                 ),
               ),
             ],
+          ),
           ),
         );
       },
@@ -624,6 +630,31 @@ class _MainScreenState extends State<MainScreen> {
     );
     await _restoreEditorFocus();
   }
+
+  /// Makes bare arrow keys move focus between rows in a picker sheet.
+  ///
+  /// Required on Web and nowhere else. WidgetsApp.defaultShortcuts returns
+  /// _defaultWebShortcuts when kIsWeb, and that map binds bare arrows to
+  /// ScrollIntent -- only Tab and Shift+Tab traverse focus. The non-web maps bind
+  /// arrows to DirectionalFocusIntent, which is why every widget test passes
+  /// while the browser cannot select a theme or font at all: in the Theme sheet
+  /// the arrows hit a non-scrolling Column and do nothing, and in the Font sheet
+  /// they scroll the list without moving the selection.
+  ///
+  /// Verified in Chrome: an ArrowUp with the Theme sheet open arrived at
+  /// flutter-view with defaultPrevented still false, i.e. the framework declined
+  /// it, and the focus highlight never left the active row.
+  ///
+  /// DirectionalFocusAction is already in the default Actions map, so supplying
+  /// the intent is all this needs.
+  static const Map<ShortcutActivator, Intent> _rowTraversalShortcuts = {
+    SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(
+      TraversalDirection.down,
+    ),
+    SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(
+      TraversalDirection.up,
+    ),
+  };
 
   /// One arrow press worth of About-sheet scrolling, in logical pixels.
   static const double _aboutArrowStep = 80;

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -327,7 +327,8 @@ class _MainScreenState extends State<MainScreen> {
     await _showSheet<void>(
       builder: (ctx) {
         final colors = colorsFor(settings.theme);
-        return Padding(
+        return _SheetInitialFocus(
+          builder: (rowFocusNode) => Padding(
           padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -355,8 +356,9 @@ class _MainScreenState extends State<MainScreen> {
                 return ListTile(
                   // Opening on the active row lets arrow keys navigate from
                   // where the user already is. Traversal, the focus highlight
-                  // and Enter activation all come from the framework.
-                  autofocus: settings.theme == theme,
+                  // and Enter activation all come from the framework; only the
+                  // initial claim is ours -- see _SheetInitialFocus.
+                  focusNode: settings.theme == theme ? rowFocusNode : null,
                   leading: Container(
                     width: 32,
                     height: 32,
@@ -376,6 +378,7 @@ class _MainScreenState extends State<MainScreen> {
                 );
               }),
             ],
+          ),
           ),
         );
       },
@@ -643,6 +646,52 @@ class _MainScreenState extends State<MainScreen> {
       curve: Curves.easeOut,
     );
   }
+}
+
+/// Owns a [FocusNode] for the row a sheet should open on, and claims focus for
+/// it once the sheet has built.
+///
+/// ListTile.autofocus is not enough on Web. It registers the right node -- a
+/// single Tab lands on exactly the row autofocus named -- but it depends on the
+/// modal route's FocusScope taking focus when the route is pushed, and that does
+/// not happen in a browser. Verified in Chrome against this build: with the
+/// Theme sheet fully open, document.activeElement was still the *toolbar
+/// button* that opened it, outside the sheet's route. Arrows therefore traversed
+/// the toolbar behind the barrier and Enter re-fired a toolbar button, which
+/// reads to the user as the keyboard doing nothing at all. Requesting focus on a
+/// real node after the frame does not wait for the scope to claim anything.
+///
+/// Widget tests cannot catch this: the test binding pushes focus into the route
+/// scope, and the Theme sheet's test only ever runs with the default theme,
+/// whose row is first in the list either way.
+class _SheetInitialFocus extends StatefulWidget {
+  final Widget Function(FocusNode rowFocusNode) builder;
+
+  const _SheetInitialFocus({required this.builder});
+
+  @override
+  State<_SheetInitialFocus> createState() => _SheetInitialFocusState();
+}
+
+class _SheetInitialFocusState extends State<_SheetInitialFocus> {
+  final FocusNode _rowFocusNode = FocusNode(debugLabel: 'sheet initial row');
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _rowFocusNode.requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    _rowFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.builder(_rowFocusNode);
 }
 
 /// A bottom sheet that collects one whole number in a range.
@@ -1009,10 +1058,25 @@ class _FontListState extends State<_FontList> {
 
   static const List<String?> _options = [null, ...availableFonts];
 
+  final FocusNode _selectedNode = FocusNode(debugLabel: 'selected font');
+
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _revealSelection());
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      _revealSelection();
+      // The jump above changes which rows exist, so the selected row is only
+      // built on the frame after it. Requesting focus any earlier targets a node
+      // with no context. See _SheetInitialFocus for why autofocus is not enough.
+      await WidgetsBinding.instance.endOfFrame;
+      if (mounted) _selectedNode.requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    _selectedNode.dispose();
+    super.dispose();
   }
 
   void _revealSelection() {
@@ -1036,10 +1100,12 @@ class _FontListState extends State<_FontList> {
       itemCount: _options.length,
       itemBuilder: (context, index) {
         final family = _options[index];
+        final selected = family == widget.selectedFamily;
         return _FontTile(
           label: family ?? 'Source Code Pro (Default)',
           style: GoogleFonts.getFont(family ?? 'Source Code Pro'),
-          selected: family == widget.selectedFamily,
+          selected: selected,
+          focusNode: selected ? _selectedNode : null,
           onTap: () => widget.onSelected(family),
         );
       },
@@ -1051,12 +1117,14 @@ class _FontTile extends StatelessWidget {
   final String label;
   final TextStyle style;
   final bool selected;
+  final FocusNode? focusNode;
   final VoidCallback onTap;
 
   const _FontTile({
     required this.label,
     required this.style,
     required this.selected,
+    required this.focusNode,
     required this.onTap,
   });
 
@@ -1064,8 +1132,9 @@ class _FontTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
       // Opening on the active row lets arrow keys navigate from where the user
-      // already is.
-      autofocus: selected,
+      // already is. The initial focus claim is explicit rather than autofocus --
+      // see _SheetInitialFocus.
+      focusNode: focusNode,
       title: Text(label, style: style),
       trailing: selected ? const Icon(Icons.check) : null,
       selected: selected,

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -24,6 +24,10 @@ extension AppThemeExtension on AppTheme {
 
 class AppColors {
   final Color background;
+
+  /// Surface for bottom sheets. Must differ from [background] so a sheet has a
+  /// visible edge against the editor behind it.
+  final Color sheetBackground;
   final Color text;
   final Color textSecondary;
   final Color buttonBackground;
@@ -31,6 +35,7 @@ class AppColors {
 
   const AppColors({
     required this.background,
+    required this.sheetBackground,
     required this.text,
     required this.textSecondary,
     required this.buttonBackground,
@@ -40,6 +45,7 @@ class AppColors {
 
 const lightColors = AppColors(
   background: Color(0xFFFFFFFF),
+  sheetBackground: Color(0xFFF4F0F7),
   text: Color(0xFF000000),
   textSecondary: Color(0xFF666666),
   buttonBackground: Color(0xFFE8DEF8),
@@ -48,6 +54,7 @@ const lightColors = AppColors(
 
 const darkColors = AppColors(
   background: Color(0xFF121212),
+  sheetBackground: Color(0xFF1E1E1E),
   text: Color(0xFFFFFFFF),
   textSecondary: Color(0xFFB0B0B0),
   buttonBackground: Color(0xFF2C2C2C),
@@ -56,6 +63,7 @@ const darkColors = AppColors(
 
 const sepiaColors = AppColors(
   background: Color(0xFFE8D5B8),
+  sheetBackground: Color(0xFFF2E4CE),
   text: Color(0xFF2C1810),
   textSecondary: Color(0xFF4E342E),
   buttonBackground: Color(0xFFC9AD88),
@@ -88,6 +96,9 @@ ThemeData themeDataFor(AppTheme theme) {
       surface: colors.background,
       onSurface: colors.text,
       onSurfaceVariant: colors.textSecondary,
+    ),
+    bottomSheetTheme: BottomSheetThemeData(
+      backgroundColor: colors.sheetBackground,
     ),
     dialogTheme: DialogThemeData(
       backgroundColor: colors.background,

--- a/test/android_manifest_test.dart
+++ b/test/android_manifest_test.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Flutter's debug manifest grants INTERNET automatically for hot reload, so
+  // downloading Google Fonts works in development even when the main manifest
+  // is missing the permission -- the failure only appears in release builds.
+  // This test closes that gap.
+  test('Android release manifest allows uncached Google Fonts to download', () {
+    final manifest = File(
+      'android/app/src/main/AndroidManifest.xml',
+    ).readAsStringSync();
+
+    expect(
+      manifest,
+      matches(
+        RegExp(
+          r'<uses-permission\s+android:name="android\.permission\.INTERNET"\s*/>',
+        ),
+      ),
+      reason: 'Release builds cannot fetch uncached fonts without INTERNET',
+    );
+  });
+}

--- a/test/framework_assumptions_test.dart
+++ b/test/framework_assumptions_test.dart
@@ -11,6 +11,7 @@
 // Flutter upgrade, the fix is to add the corresponding behaviour back to
 // main_screen.dart -- not to delete the test.
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -113,6 +114,34 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Character Limit'), findsNothing);
+  });
+
+  test('bare arrows traverse focus off-Web but scroll on Web', () {
+    // The single most important platform difference in this app's keyboard
+    // support. WidgetsApp.defaultShortcuts returns a *different map* when
+    // kIsWeb: bare arrows become ScrollIntent and only Tab traverses focus.
+    // Every arrow-traversal test in this suite runs off-Web and therefore
+    // passes while the browser cannot select a theme or font at all.
+    //
+    // This is why the Theme and Font sheets bind arrows to
+    // DirectionalFocusIntent themselves (_rowTraversalShortcuts). If a future
+    // SDK unifies the maps, this test fails and that binding becomes redundant
+    // -- but harmless, so prefer leaving it.
+    const down = SingleActivator(LogicalKeyboardKey.arrowDown);
+    final Intent? offWeb = WidgetsApp.defaultShortcuts[down];
+
+    expect(
+      offWeb,
+      isA<DirectionalFocusIntent>(),
+      reason: 'off-Web (this test platform) bare arrows traverse focus, which is '
+          'exactly why widget tests cannot catch the Web behaviour',
+    );
+    expect(
+      kIsWeb,
+      isFalse,
+      reason: 'if this ever runs on Web, the expectation above must flip to '
+          'ScrollIntent -- see WidgetsApp._defaultWebShortcuts',
+    );
   });
 
   testWidgets('arrow keys traverse ListTiles and Enter activates the focused row', (

--- a/test/framework_assumptions_test.dart
+++ b/test/framework_assumptions_test.dart
@@ -137,6 +137,52 @@ void main() {
     expect(activated, 'Item 1');
   });
 
+  testWidgets('Enter reaches an enclosing CallbackShortcuts even while a field has focus', (
+    tester,
+  ) async {
+    var submitted = 0;
+    var shortcutFired = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CallbackShortcuts(
+            bindings: <ShortcutActivator, VoidCallback>{
+              const SingleActivator(LogicalKeyboardKey.enter): () => shortcutFired++,
+            },
+            child: Column(
+              children: [
+                TextField(autofocus: true, onSubmitted: (_) => submitted++),
+                TextButton(onPressed: () {}, child: const Text('other')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+
+    // The Font Size sheet needs Enter to commit from the slider as well as the
+    // field, so it binds Enter at the sheet level. This pins why that binding
+    // cannot be the *only* Enter path, and why the commit must be re-entrant:
+    //
+    // - A raw Enter reaches the sheet-level binding whatever holds focus, so a
+    //   field-focused Enter can trigger the sheet binding too.
+    // - A raw Enter does NOT fire onSubmitted; that arrives as a platform text
+    //   input action instead (TextInputAction.done), which is the only Enter an
+    //   Android soft keyboard produces. Dropping onSubmitted would break Enter
+    //   on mobile.
+    //
+    // On Web both fire for one keypress, hence the _closing guard on the commit
+    // path. Tests driving the field's own Enter must use
+    // testTextInput.receiveAction, not sendKeyEvent.
+    expect(shortcutFired, 1, reason: 'sheet-level Enter fires regardless of focus');
+    expect(submitted, 0, reason: 'onSubmitted comes from the platform action, not a raw key');
+  });
+
   testWidgets('focus traversal reaches and reveals off-screen tiles', (
     tester,
   ) async {

--- a/test/framework_assumptions_test.dart
+++ b/test/framework_assumptions_test.dart
@@ -1,0 +1,160 @@
+// Regression net for Flutter behaviour this app deliberately does NOT
+// reimplement.
+//
+// Rolling Text's keyboard accessibility relies on framework defaults rather
+// than custom key handling: Escape dismissal, arrow-key focus traversal, and
+// scroll-into-view all come from Flutter itself. That keeps the app code small,
+// but it means a future SDK upgrade could break accessibility with no failing
+// test to explain why.
+//
+// These tests fail loudly if that ever stops being true. If one breaks after a
+// Flutter upgrade, the fix is to add the corresponding behaviour back to
+// main_screen.dart -- not to delete the test.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:provider/provider.dart';
+import 'package:rolling_text/models/app_settings.dart';
+import 'package:rolling_text/screens/main_screen.dart';
+import 'package:rolling_text/services/preferences_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> _pumpApp(WidgetTester tester) async {
+  SharedPreferences.setMockInitialValues({});
+  PackageInfo.setMockInitialValues(
+    appName: 'Rolling Text',
+    packageName: 'io.rollingtext.rolling_text',
+    version: '0.4.0',
+    buildNumber: '1',
+    buildSignature: '',
+  );
+  final preferences = await SharedPreferences.getInstance();
+  await tester.pumpWidget(
+    ChangeNotifierProvider.value(
+      value: AppSettings(),
+      child: MaterialApp(
+        home: MainScreen(prefsService: PreferencesService(preferences)),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+/// Opens a sheet shaped like the app's Theme and Font sheets: a scrolling list
+/// of [ListTile]s inside a modal bottom sheet.
+Future<void> _pumpTileSheet(
+  WidgetTester tester, {
+  required int count,
+  required double height,
+  void Function(String label)? onActivate,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () => showModalBottomSheet(
+                context: context,
+                isScrollControlled: true,
+                builder: (_) => SizedBox(
+                  height: height,
+                  child: ListView(
+                    children: List.generate(
+                      count,
+                      (i) => ListTile(
+                        autofocus: i == 0,
+                        title: Text('Item $i'),
+                        onTap: () => onActivate?.call('Item $i'),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
+/// Walks up from the primary focus to its enclosing [ListTile] title, so tests
+/// can assert *which* row owns focus.
+String? _focusedTileLabel() {
+  final context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) return null;
+  ListTile? tile;
+  context.visitAncestorElements((element) {
+    if (element.widget is ListTile) {
+      tile = element.widget as ListTile;
+      return false;
+    }
+    return true;
+  });
+  final title = tile?.title;
+  return title is Text ? title.data : null;
+}
+
+void main() {
+  testWidgets('ModalRoute dismisses a bottom sheet on Escape', (tester) async {
+    await _pumpApp(tester);
+
+    await tester.tap(find.byIcon(Icons.tune));
+    await tester.pumpAndSettle();
+    expect(find.text('Character Limit'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Character Limit'), findsNothing);
+  });
+
+  testWidgets('arrow keys traverse ListTiles and Enter activates the focused row', (
+    tester,
+  ) async {
+    String? activated;
+    await _pumpTileSheet(
+      tester,
+      count: 20,
+      height: 400,
+      onActivate: (label) => activated = label,
+    );
+
+    expect(_focusedTileLabel(), 'Item 0');
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(_focusedTileLabel(), 'Item 1');
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(activated, 'Item 1');
+  });
+
+  testWidgets('focus traversal reaches and reveals off-screen tiles', (
+    tester,
+  ) async {
+    await _pumpTileSheet(tester, count: 21, height: 300);
+
+    final scrollable = tester.state<ScrollableState>(
+      find.descendant(of: find.byType(BottomSheet), matching: find.byType(Scrollable)),
+    );
+    expect(scrollable.position.pixels, 0);
+
+    for (var i = 0; i < 20; i++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+    }
+
+    // Tiles past the viewport are built lazily; traversal must still reach them
+    // and scroll them into view without any manual scroll math.
+    expect(_focusedTileLabel(), 'Item 20');
+    expect(scrollable.position.pixels, greaterThan(0));
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -79,10 +79,8 @@ String? _focusedTileLabel() {
   return title is Text ? title.data : null;
 }
 
-Future<void> _openCustomFontSize(WidgetTester tester) async {
+Future<void> _openFontSize(WidgetTester tester) async {
   await tester.tap(find.byIcon(Icons.format_size));
-  await tester.pumpAndSettle();
-  await tester.tap(find.text('Enter custom size…'));
   await tester.pumpAndSettle();
 }
 
@@ -141,11 +139,11 @@ void main() {
       expect(_settings(tester).maxChars, 200);
     });
 
-    testWidgets('custom font size preselects its value so typing replaces it', (
+    testWidgets('font size preselects its value so typing replaces it', (
       tester,
     ) async {
       await _pumpMainScreen(tester);
-      await _openCustomFontSize(tester);
+      await _openFontSize(tester);
 
       final input = _sheetInput(tester);
       expect(
@@ -154,16 +152,46 @@ void main() {
       );
     });
 
-    testWidgets('custom font size applies on Enter', (tester) async {
+    testWidgets('font size applies on Enter', (tester) async {
       await _pumpMainScreen(tester);
-      await _openCustomFontSize(tester);
+      await _openFontSize(tester);
 
       await tester.enterText(find.byType(TextField).last, '42');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
 
-      expect(find.text('Custom Font Size'), findsNothing);
+      expect(find.text('Font Size'), findsNothing);
       expect(_settings(tester).fontSize, 42);
+    });
+
+    testWidgets('font size applies live while typing, before Enter', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+      await _openFontSize(tester);
+
+      await tester.enterText(find.byType(TextField).last, '42');
+      await tester.pump();
+
+      expect(find.text('Font Size'), findsOneWidget);
+      expect(_settings(tester).fontSize, 42);
+    });
+
+    testWidgets('the slider is one Tab away from the font size field', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+      await _openFontSize(tester);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pumpAndSettle();
+
+      final focused = FocusManager.instance.primaryFocus;
+      expect(
+        focused?.context?.findAncestorWidgetOfExactType<Slider>(),
+        isNotNull,
+        reason: 'One Tab from the autofocused field should reach the slider',
+      );
     });
   });
 
@@ -245,20 +273,19 @@ void main() {
       expect(_settings(tester).maxChars, before);
     });
 
-    testWidgets('an invalid font size keeps the sheet open', (tester) async {
+    testWidgets('an invalid font size keeps the sheet open with an inline error', (
+      tester,
+    ) async {
       await _pumpMainScreen(tester);
       final before = _settings(tester).fontSize;
 
-      await _openCustomFontSize(tester);
+      await _openFontSize(tester);
       await tester.enterText(find.byType(TextField).last, '3');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
 
-      expect(find.text('Invalid Input'), findsOneWidget);
-      await tester.tap(find.text('OK'));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Custom Font Size'), findsOneWidget);
+      expect(find.text('Font Size'), findsOneWidget);
+      expect(find.text('Enter a size between 6 and 999 pt'), findsOneWidget);
       expect(_settings(tester).fontSize, before);
     });
   });

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -193,6 +193,70 @@ void main() {
         reason: 'One Tab from the autofocused field should reach the slider',
       );
     });
+
+    testWidgets('Enter commits the font size while the slider holds focus', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+      await _openFontSize(tester);
+
+      await tester.enterText(find.byType(TextField).last, '42');
+      await tester.pump();
+      // Tab to the slider: it ignores Enter itself, so without a sheet-level
+      // binding there is no keyboard way to commit after touching it.
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Font Size'), findsNothing);
+      expect(_settings(tester).fontSize, 42);
+    });
+
+    testWidgets('Apply commits the font size', (tester) async {
+      await _pumpMainScreen(tester);
+      await _openFontSize(tester);
+
+      await tester.enterText(find.byType(TextField).last, '42');
+      await tester.pump();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Font Size'), findsNothing);
+      expect(_settings(tester).fontSize, 42);
+    });
+
+    testWidgets('Cancel reverts the previewed font size', (tester) async {
+      await _pumpMainScreen(tester);
+      final before = _settings(tester).fontSize;
+      await _openFontSize(tester);
+
+      await tester.enterText(find.byType(TextField).last, '42');
+      await tester.pump();
+      expect(
+        _settings(tester).fontSize,
+        42,
+        reason: 'the size previews live while the sheet is open',
+      );
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(_settings(tester).fontSize, before);
+    });
+
+    testWidgets('Escape reverts the previewed font size', (tester) async {
+      await _pumpMainScreen(tester);
+      final before = _settings(tester).fontSize;
+      await _openFontSize(tester);
+
+      await tester.enterText(find.byType(TextField).last, '42');
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      expect(_settings(tester).fontSize, before);
+    });
   });
 
   group('numeric sheets only commit valid values', () {
@@ -208,10 +272,12 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
 
-      expect(find.text('Invalid Input'), findsOneWidget);
-      await tester.tap(find.text('OK'));
-      await tester.pumpAndSettle();
-
+      expect(
+        find.text('Please enter a number between 1 and 1,000,000'),
+        findsOneWidget,
+        reason: 'the error is inline, matching the Font Size sheet',
+      );
+      expect(find.text('Invalid Input'), findsNothing, reason: 'no dialog');
       expect(
         find.text('Character Limit'),
         findsOneWidget,
@@ -231,8 +297,6 @@ void main() {
       await tester.enterText(find.byType(TextField).last, '0');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
-      await tester.tap(find.text('OK'));
-      await tester.pumpAndSettle();
 
       expect(
         _sheetInput(tester).selection,
@@ -248,8 +312,6 @@ void main() {
       await tester.pumpAndSettle();
       await tester.enterText(find.byType(TextField).last, '0');
       await tester.testTextInput.receiveAction(TextInputAction.done);
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('OK'));
       await tester.pumpAndSettle();
 
       await tester.enterText(find.byType(TextField).last, '300');
@@ -530,6 +592,36 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(scrollable.position.pixels, greaterThan(0));
+    });
+
+    testWidgets('arrow keys reach the very bottom of the about text', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+      final scrollable = await openAbout(tester);
+
+      // The previous implementation anchored focus inside the lazy ListView.
+      // Once that anchor scrolled past the cache extent it was unmounted,
+      // ScrollAction lost the Scrollable it resolves from the focused node, and
+      // the arrows died partway down -- while the mouse wheel still worked.
+      // Two presses stayed inside the cache extent, so the old tests passed.
+      var lastPixels = scrollable.position.pixels;
+      var stalledFor = 0;
+      for (var i = 0; i < 200; i++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pumpAndSettle();
+        final pixels = scrollable.position.pixels;
+        stalledFor = pixels > lastPixels ? 0 : stalledFor + 1;
+        lastPixels = pixels;
+        if (stalledFor > 2) break;
+      }
+
+      expect(
+        lastPixels,
+        moreOrLessEquals(scrollable.position.maxScrollExtent, epsilon: 1),
+        reason: 'arrows must reach the end of the content, not stall partway',
+      );
+      expect(scrollable.position.maxScrollExtent, greaterThan(0));
     });
   });
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -579,9 +579,7 @@ void main() {
       await expectTypingReachesEditor(tester);
     });
 
-    testWidgets('after a limit reduction confirms the truncation warning', (
-      tester,
-    ) async {
+    testWidgets('after a limit reduction truncates the text', (tester) async {
       await _pumpMainScreen(tester);
       await tester.enterText(find.byType(TextField).first, 'abcdefghij');
       await tester.pump();
@@ -592,11 +590,19 @@ void main() {
       await tester.tap(find.text('Apply'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Warning'), findsOneWidget);
-      await tester.tap(find.text('Yes'));
-      await tester.pumpAndSettle();
+      expect(
+        find.text('Warning'),
+        findsNothing,
+        reason: 'a lower limit applies without asking for confirmation',
+      );
+      expect(find.text('Character Limit'), findsNothing);
+      expect(_settings(tester).maxChars, 5);
+      expect(
+        editorText(tester),
+        'fghij',
+        reason: 'truncation drops the oldest characters, not the newest',
+      );
 
-      // Focus must wait for the warning dialog, not just the sheet.
       await expectTypingReachesEditor(tester);
     });
   });

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -364,6 +364,102 @@ void main() {
     });
   });
 
+  group('the editor is typeable again after every sheet closes', () {
+    // Asserting FocusNode.hasFocus would pass even when the editor has no live
+    // input connection, which is the exact failure this guards against. So each
+    // case sends text through the active input client with no widget target and
+    // checks it lands in the editor.
+    String editorText(WidgetTester tester) => tester
+        .widget<TextField>(find.byType(TextField).first)
+        .controller!
+        .text;
+
+    Future<void> expectTypingReachesEditor(WidgetTester tester) async {
+      tester.testTextInput.enterText('typed');
+      await tester.pumpAndSettle();
+      expect(editorText(tester), 'typed');
+    }
+
+    testWidgets('after Escape dismisses the theme sheet', (tester) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.palette_outlined));
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      await expectTypingReachesEditor(tester);
+    });
+
+    testWidgets('after choosing a font with Enter', (tester) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.text_format));
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      await expectTypingReachesEditor(tester);
+    });
+
+    testWidgets('after cancelling the character limit sheet', (tester) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      await expectTypingReachesEditor(tester);
+    });
+
+    testWidgets('after applying a new character limit', (tester) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).last, '300');
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      await expectTypingReachesEditor(tester);
+    });
+
+    testWidgets('after dismissing the about sheet by tapping the barrier', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.info_outline));
+      await tester.pumpAndSettle();
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+
+      await expectTypingReachesEditor(tester);
+    });
+
+    testWidgets('after a limit reduction confirms the truncation warning', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+      await tester.enterText(find.byType(TextField).first, 'abcdefghij');
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).last, '5');
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Warning'), findsOneWidget);
+      await tester.tap(find.text('Yes'));
+      await tester.pumpAndSettle();
+
+      // Focus must wait for the warning dialog, not just the sheet.
+      await expectTypingReachesEditor(tester);
+    });
+  });
+
   group('about sheet is readable from the keyboard', () {
     Future<ScrollableState> openAbout(WidgetTester tester) async {
       await tester.tap(find.byIcon(Icons.info_outline));

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,45 +5,86 @@ import 'package:provider/provider.dart';
 import 'package:rolling_text/models/app_settings.dart';
 import 'package:rolling_text/screens/main_screen.dart';
 import 'package:rolling_text/services/preferences_service.dart';
+import 'package:rolling_text/theme/app_theme.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+/// Pumps the app the way [RollingTextApp] does, including the real
+/// [themeDataFor] theme. Tests that pump a bare MaterialApp silently get
+/// Flutter's default light theme and cannot catch contrast regressions.
+Future<void> _pumpMainScreen(
+  WidgetTester tester, {
+  AppTheme theme = AppTheme.light,
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  PackageInfo.setMockInitialValues(
+    appName: 'Rolling Text',
+    packageName: 'io.rollingtext.rolling_text',
+    version: '0.4.0',
+    buildNumber: '1',
+    buildSignature: '',
+  );
+  final preferences = await SharedPreferences.getInstance();
+  final settings = AppSettings()..setTheme(theme);
+
+  await tester.pumpWidget(
+    ChangeNotifierProvider.value(
+      value: settings,
+      child: MaterialApp(
+        theme: themeDataFor(theme),
+        home: MainScreen(prefsService: PreferencesService(preferences)),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+/// Reads the colour a bottom sheet actually paints, rather than the value of a
+/// constructor argument, so the assertion reflects what the user sees.
+Color _sheetSurfaceColor(WidgetTester tester) {
+  final material = tester.widget<Material>(
+    find
+        .descendant(of: find.byType(BottomSheet), matching: find.byType(Material))
+        .first,
+  );
+  return material.color!;
+}
 
 void main() {
   testWidgets('editor renders one app-owned hint until text is entered', (
     tester,
   ) async {
-    SharedPreferences.setMockInitialValues({});
-    PackageInfo.setMockInitialValues(
-      appName: 'Rolling Text',
-      packageName: 'io.rollingtext.rolling_text',
-      version: '0.4.0',
-      buildNumber: '1',
-      buildSignature: '',
-    );
-    final preferences = await SharedPreferences.getInstance();
+    await _pumpMainScreen(tester);
 
-    await tester.pumpWidget(
-      ChangeNotifierProvider(
-        create: (_) => AppSettings(),
-        child: MaterialApp(
-          home: MainScreen(prefsService: PreferencesService(preferences)),
-        ),
-      ),
-    );
-    await tester.pump();
-
-    expect(find.text('Start typing\u2026'), findsOneWidget);
+    expect(find.text('Start typing…'), findsOneWidget);
     final editor = tester.widget<TextField>(find.byType(TextField).first);
     expect(editor.decoration?.hintText, isNull);
     expect(tester.getSize(find.byType(TextField).first).width, greaterThan(700));
     expect(
-      tester.getTopLeft(find.text('Start typing\u2026')),
+      tester.getTopLeft(find.text('Start typing…')),
       tester.getTopLeft(find.byType(TextField).first),
     );
 
     await tester.enterText(find.byType(TextField).first, 'Hello');
     await tester.pump();
 
-    expect(find.text('Start typing\u2026'), findsNothing);
+    expect(find.text('Start typing…'), findsNothing);
     expect(tester.getSize(find.byType(TextField).first).width, greaterThan(700));
   });
+
+  for (final theme in AppTheme.values) {
+    testWidgets('${theme.label} sheets are distinguishable from the editor', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester, theme: theme);
+
+      await tester.tap(find.byIcon(Icons.palette_outlined));
+      await tester.pumpAndSettle();
+
+      expect(
+        _sheetSurfaceColor(tester),
+        isNot(colorsFor(theme).background),
+        reason: 'A sheet painted in the editor background has no visible edge',
+      );
+    });
+  }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -223,9 +223,6 @@ void main() {
       expect(find.text('Select Font'), findsNothing);
     });
 
-    // SKIPPED -- known gap, not a flaky test. The font list always opens at the
-    // top, so a selection past the viewport is never built and cannot take
-    // autofocus. Fixing it needs scroll-to-selection when the sheet opens.
     testWidgets('font sheet reveals an active font far down the list', (
       tester,
     ) async {
@@ -238,7 +235,7 @@ void main() {
 
       expect(_focusedTileLabel(), 'Work Sans');
       expect(find.text('Work Sans'), findsOneWidget);
-    }, skip: true);
+    });
 
     testWidgets('Enter activates the focused control, not the list', (
       tester,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
@@ -14,6 +15,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 Future<void> _pumpMainScreen(
   WidgetTester tester, {
   AppTheme theme = AppTheme.light,
+  String? fontFamily,
 }) async {
   SharedPreferences.setMockInitialValues({});
   PackageInfo.setMockInitialValues(
@@ -25,6 +27,7 @@ Future<void> _pumpMainScreen(
   );
   final preferences = await SharedPreferences.getInstance();
   final settings = AppSettings()..setTheme(theme);
+  if (fontFamily != null) settings.setFontFamily(fontFamily);
 
   await tester.pumpWidget(
     ChangeNotifierProvider.value(
@@ -58,6 +61,23 @@ AppSettings _settings(WidgetTester tester) => Provider.of<AppSettings>(
 /// screen, so the sheet's own field is the last.
 TextEditingController _sheetInput(WidgetTester tester) =>
     tester.widgetList<TextField>(find.byType(TextField)).last.controller!;
+
+/// Walks up from the primary focus to its enclosing [ListTile] title, so tests
+/// can assert *which* row owns focus.
+String? _focusedTileLabel() {
+  final context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) return null;
+  ListTile? tile;
+  context.visitAncestorElements((element) {
+    if (element.widget is ListTile) {
+      tile = element.widget as ListTile;
+      return false;
+    }
+    return true;
+  });
+  final title = tile?.title;
+  return title is Text ? title.data : null;
+}
 
 Future<void> _openCustomFontSize(WidgetTester tester) async {
   await tester.tap(find.byIcon(Icons.format_size));
@@ -144,6 +164,110 @@ void main() {
 
       expect(find.text('Custom Font Size'), findsNothing);
       expect(_settings(tester).fontSize, 42);
+    });
+  });
+
+  group('theme and font sheets are keyboard navigable', () {
+    testWidgets('theme sheet opens with the active theme focused', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester, theme: AppTheme.sepia);
+
+      await tester.tap(find.byIcon(Icons.palette_outlined));
+      await tester.pumpAndSettle();
+
+      expect(_focusedTileLabel(), 'Sepia');
+    });
+
+    testWidgets('theme sheet applies the focused theme on Enter', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+      expect(_settings(tester).theme, AppTheme.light);
+
+      await tester.tap(find.byIcon(Icons.palette_outlined));
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(_focusedTileLabel(), 'Dark');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      expect(_settings(tester).theme, AppTheme.dark);
+      expect(find.text('Select Theme'), findsNothing);
+    });
+
+    testWidgets('font sheet opens with the active font focused', (tester) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.text_format));
+      await tester.pumpAndSettle();
+
+      expect(_focusedTileLabel(), 'Source Code Pro (Default)');
+    });
+
+    testWidgets('font sheet applies the focused font on Enter', (tester) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.text_format));
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(_focusedTileLabel(), 'Courier Prime');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      expect(_settings(tester).fontFamily, 'Courier Prime');
+      expect(find.text('Select Font'), findsNothing);
+    });
+
+    // SKIPPED -- known gap, not a flaky test. The font list always opens at the
+    // top, so a selection past the viewport is never built and cannot take
+    // autofocus. Fixing it needs scroll-to-selection when the sheet opens.
+    testWidgets('font sheet reveals an active font far down the list', (
+      tester,
+    ) async {
+      // Work Sans is last of 20. Tiles past the viewport are built lazily, so a
+      // tile that is never built cannot take autofocus.
+      await _pumpMainScreen(tester, fontFamily: 'Work Sans');
+
+      await tester.tap(find.byIcon(Icons.text_format));
+      await tester.pumpAndSettle();
+
+      expect(_focusedTileLabel(), 'Work Sans');
+      expect(find.text('Work Sans'), findsOneWidget);
+    }, skip: true);
+
+    testWidgets('Enter activates the focused control, not the list', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.palette_outlined));
+      await tester.pumpAndSettle();
+
+      // Move focus off the list and onto the Close button.
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab, character: null);
+      await tester.pumpAndSettle();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pumpAndSettle();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pumpAndSettle();
+      expect(_focusedTileLabel(), isNull, reason: 'focus should be off the list');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      // A sheet-wide Enter binding would apply a theme here instead of
+      // activating the focused button.
+      expect(find.text('Select Theme'), findsNothing);
+      expect(_settings(tester).theme, AppTheme.light);
     });
   });
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -365,6 +365,10 @@ void main() {
   });
 
   group('the editor is typeable again after every sheet closes', () {
+    // These run on the native test platform, where _restoreEditorFocus no-ops
+    // and ModalRoute restores focus by itself. They do not cover the Web fix --
+    // browser focus is only checkable in a real browser.
+    //
     // Asserting FocusNode.hasFocus would pass even when the editor has no live
     // input connection, which is the exact failure this guards against. So each
     // case sends text through the active input client with no widget target and

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -364,6 +364,48 @@ void main() {
     });
   });
 
+  group('about sheet is readable from the keyboard', () {
+    Future<ScrollableState> openAbout(WidgetTester tester) async {
+      await tester.tap(find.byIcon(Icons.info_outline));
+      await tester.pumpAndSettle();
+      return tester.state<ScrollableState>(
+        find
+            .descendant(
+              of: find.byType(BottomSheet),
+              matching: find.byType(Scrollable),
+            )
+            .last,
+      );
+    }
+
+    testWidgets('arrow keys scroll the about text', (tester) async {
+      await _pumpMainScreen(tester);
+      final scrollable = await openAbout(tester);
+      final start = scrollable.position.pixels;
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      final afterDown = scrollable.position.pixels;
+      expect(afterDown, greaterThan(start));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pumpAndSettle();
+      expect(scrollable.position.pixels, lessThan(afterDown));
+    });
+
+    testWidgets('page keys scroll the about text further than arrows', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+      final scrollable = await openAbout(tester);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.pageDown);
+      await tester.pumpAndSettle();
+
+      expect(scrollable.position.pixels, greaterThan(0));
+    });
+  });
+
   for (final theme in AppTheme.values) {
     testWidgets('${theme.label} sheets are distinguishable from the editor', (
       tester,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -49,6 +49,23 @@ Color _sheetSurfaceColor(WidgetTester tester) {
   return material.color!;
 }
 
+AppSettings _settings(WidgetTester tester) => Provider.of<AppSettings>(
+  tester.element(find.byType(MainScreen)),
+  listen: false,
+);
+
+/// The numeric field inside an open sheet. The editor is the first TextField on
+/// screen, so the sheet's own field is the last.
+TextEditingController _sheetInput(WidgetTester tester) =>
+    tester.widgetList<TextField>(find.byType(TextField)).last.controller!;
+
+Future<void> _openCustomFontSize(WidgetTester tester) async {
+  await tester.tap(find.byIcon(Icons.format_size));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Enter custom size…'));
+  await tester.pumpAndSettle();
+}
+
 void main() {
   testWidgets('editor renders one app-owned hint until text is entered', (
     tester,
@@ -69,6 +86,65 @@ void main() {
 
     expect(find.text('Start typing…'), findsNothing);
     expect(tester.getSize(find.byType(TextField).first).width, greaterThan(700));
+  });
+
+  group('numeric sheets are usable from the keyboard alone', () {
+    testWidgets('character limit preselects its value so typing replaces it', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+
+      final expected = '${_settings(tester).maxChars}';
+      final input = _sheetInput(tester);
+      expect(input.text, expected);
+      expect(
+        input.selection,
+        TextSelection(baseOffset: 0, extentOffset: expected.length),
+        reason: 'Without a full selection the first keystroke appends to the '
+            'existing limit instead of replacing it',
+      );
+    });
+
+    testWidgets('character limit applies on Enter', (tester) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).last, '200');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Character Limit'), findsNothing);
+      expect(_settings(tester).maxChars, 200);
+    });
+
+    testWidgets('custom font size preselects its value so typing replaces it', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+      await _openCustomFontSize(tester);
+
+      final input = _sheetInput(tester);
+      expect(
+        input.selection,
+        TextSelection(baseOffset: 0, extentOffset: input.text.length),
+      );
+    });
+
+    testWidgets('custom font size applies on Enter', (tester) async {
+      await _pumpMainScreen(tester);
+      await _openCustomFontSize(tester);
+
+      await tester.enterText(find.byType(TextField).last, '42');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Custom Font Size'), findsNothing);
+      expect(_settings(tester).fontSize, 42);
+    });
   });
 
   for (final theme in AppTheme.values) {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -453,6 +453,54 @@ void main() {
     });
   });
 
+  group('picker sheets bind arrow traversal themselves', () {
+    // On Web, WidgetsApp.defaultShortcuts maps bare arrows to ScrollIntent, so
+    // arrow selection only works because these sheets ask for it. A test that
+    // just presses arrows passes on this platform either way and cannot detect
+    // the binding going missing -- so assert the binding itself.
+    void expectArrowTraversalBinding(WidgetTester tester) {
+      final shortcuts = tester
+          .widgetList<Shortcuts>(
+            find.descendant(
+              of: find.byType(BottomSheet),
+              matching: find.byType(Shortcuts),
+            ),
+          )
+          .expand((s) => s.shortcuts.entries)
+          .toList();
+
+      for (final key in [LogicalKeyboardKey.arrowDown, LogicalKeyboardKey.arrowUp]) {
+        expect(
+          shortcuts.any((e) {
+            final activator = e.key;
+            return activator is SingleActivator &&
+                activator.trigger == key &&
+                e.value is DirectionalFocusIntent;
+          }),
+          isTrue,
+          reason: '${key.keyLabel} must be bound to DirectionalFocusIntent, or '
+              'the sheet is unusable by keyboard on Web',
+        );
+      }
+    }
+
+    testWidgets('the theme sheet does', (tester) async {
+      await _pumpMainScreen(tester);
+      await tester.tap(find.byIcon(Icons.palette_outlined));
+      await tester.pumpAndSettle();
+
+      expectArrowTraversalBinding(tester);
+    });
+
+    testWidgets('the font sheet does', (tester) async {
+      await _pumpMainScreen(tester);
+      await tester.tap(find.byIcon(Icons.text_format));
+      await tester.pumpAndSettle();
+
+      expectArrowTraversalBinding(tester);
+    });
+  });
+
   group('the editor is typeable again after every sheet closes', () {
     // These run on the native test platform, where _restoreEditorFocus no-ops
     // and ModalRoute restores focus by itself. They do not cover the Web fix --

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -167,6 +167,102 @@ void main() {
     });
   });
 
+  group('numeric sheets only commit valid values', () {
+    testWidgets('an invalid limit keeps the sheet open with the value intact', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+      final before = _settings(tester).maxChars;
+
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).last, '0');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invalid Input'), findsOneWidget);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Character Limit'),
+        findsOneWidget,
+        reason: 'Closing the sheet would discard the value the user must fix',
+      );
+      expect(_sheetInput(tester).text, '0');
+      expect(_settings(tester).maxChars, before);
+    });
+
+    testWidgets('a rejected limit is refocused and reselected for retyping', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).last, '0');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      expect(
+        _sheetInput(tester).selection,
+        const TextSelection(baseOffset: 0, extentOffset: 1),
+      );
+      expect(tester.testTextInput.hasAnyClients, isTrue);
+    });
+
+    testWidgets('a corrected limit applies after a rejection', (tester) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).last, '0');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).last, '300');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Character Limit'), findsNothing);
+      expect(_settings(tester).maxChars, 300);
+    });
+
+    testWidgets('cancelling the limit sheet changes nothing', (tester) async {
+      await _pumpMainScreen(tester);
+      final before = _settings(tester).maxChars;
+
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).last, '900');
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(_settings(tester).maxChars, before);
+    });
+
+    testWidgets('an invalid font size keeps the sheet open', (tester) async {
+      await _pumpMainScreen(tester);
+      final before = _settings(tester).fontSize;
+
+      await _openCustomFontSize(tester);
+      await tester.enterText(find.byType(TextField).last, '3');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invalid Input'), findsOneWidget);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Custom Font Size'), findsOneWidget);
+      expect(_settings(tester).fontSize, before);
+    });
+  });
+
   group('theme and font sheets are keyboard navigable', () {
     testWidgets('theme sheet opens with the active theme focused', (
       tester,


### PR DESCRIPTION
Makes every settings bottom sheet operable without a mouse, and fixes the Web-specific
focus problems that surfaced while doing it.

Closes #27
Closes #30
Closes #15

## What changed

**Keyboard operation of the sheets**
- Escape dismisses every sheet; Enter submits the numeric ones.
- Theme and Font sheets open on the *active* row and are navigable with the arrow keys.
- The Font sheet reveals a selected font that sits below the fold, since a row that is
  never built can neither be seen nor take focus.
- The About sheet scrolls with the arrow and page keys, all the way to the end.

**Font Size sheet, reworked**
- Opens with the numeric field focused and its value preselected, so it is typeable
  immediately. The slider is one Tab away.
- Typing or dragging previews live; Apply commits.
- The separate "Enter custom size…" button and its second sheet are gone. That chained
  sheet was untypeable on Web anyway: the outer sheet's route completed while the inner
  one was already open, so focus restoration stole the field's focus.

**Validation messages**
- Both numeric sheets show inline `errorText` and keep the sheet open. No dialogs remain
  anywhere in `lib/`.
- Reducing the character limit below the current text length no longer asks for
  confirmation — it applies and closes (#30).

**Editor focus after a sheet closes**
- On Web, dismissing a sheet left the browser with no focused input element, so the
  editor silently stopped accepting keystrokes. Fixed by cycling unfocus → frame →
  refocus, gated to Web with `kIsWeb`: running it on Android reopened the software
  keyboard on every dismissal, a visible flicker confirmed on a Pixel 8 Pro.

**Android release builds (#15)**
- Release builds could not download uncached Google Fonts. Manifest fix plus a test that
  pins it.

## Notable Web-only findings

Two Flutter behaviours caused bugs that every widget test passed straight through,
because the test binding is not the browser:

1. **`WidgetsApp.defaultShortcuts` returns a different map when `kIsWeb`.** Bare arrow
   keys map to `ScrollIntent`, not `DirectionalFocusIntent` — on Web only Tab traverses
   focus. That is why the Theme sheet ignored arrows entirely while the Font sheet
   scrolled without moving the selection. The picker sheets now bind arrows themselves.
2. **`ListTile.autofocus` does not claim focus inside a modal route on Web.** With a
   sheet fully open, `document.activeElement` was still the toolbar button behind the
   barrier. Focus is now requested explicitly after the frame.

Both are recorded in `test/framework_assumptions_test.dart`, which asserts the framework
behaviours this app deliberately does not reimplement, so an SDK upgrade that changes
them fails loudly instead of silently degrading accessibility.

## Testing

53 tests (16 on `main`). Manual UAT on the Web release build, plus an Android release
build on a Pixel 8 Pro.

Note that arrow-traversal tests pass off-Web whether or not the bindings exist, so the
regression tests assert the *bindings are present* rather than simulating key presses.

## Reviewer notes

- **Behaviour change:** the Font Size sheet's live preview is a true preview. Apply
  commits; Cancel, Escape, the close button and a barrier tap all revert to the size the
  sheet opened with.
- **iOS is untested.** It takes the same native path as Android, which passed on device,
  but nobody has run it on iOS hardware.
- **#29 is deliberately out of scope.** The editor loses text input after a tap on empty
  space or a window blur, recoverable only by reload. That reproduces on `main` at
  `1de80bb`, so it predates this branch and belongs on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)