### PR TITLE
build: cut releases from tags with composed notes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,8 +1,13 @@
-name: Build APKs
+name: Build and release
 
+# Release creation and APK building must stay in ONE workflow. GitHub does not start a
+# new workflow run from an event raised by the default GITHUB_TOKEN, so splitting these
+# -- a tag-triggered job that creates the release, plus a separate `on: release` job that
+# attaches APKs -- would leave the second job unfired and publish releases with no APKs.
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
 
 jobs:
@@ -20,6 +25,20 @@ jobs:
 
       - name: Install dependencies
         run: flutter pub get
+
+      - name: Check the tag matches pubspec version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pubspec_version="$(sed -nE 's/^version: *([^+]+).*/\1/p' pubspec.yaml)"
+          if [ "$tag_version" != "$pubspec_version" ]; then
+            echo "Tag $GITHUB_REF_NAME implies $tag_version but pubspec.yaml declares $pubspec_version." >&2
+            echo "The APK filename and the version shown in the app would disagree." >&2
+            exit 1
+          fi
+
+      - name: Run tests
+        run: flutter test
 
       - name: Decode keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > android/app/release.jks
@@ -40,22 +59,43 @@ jobs:
       - name: Build debug APK
         run: flutter build apk --debug
 
+      # Read the version from pubspec rather than the ref: on workflow_dispatch
+      # GITHUB_REF_NAME is a branch name, and a branch like build/foo would produce a
+      # path with a slash in it and fail the copy. The check above guarantees pubspec and
+      # the tag agree on tag builds.
       - name: Rename APKs
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="$(sed -nE 's/^version: *([^+]+).*/\1/p' pubspec.yaml)"
           cp build/app/outputs/flutter-apk/app-release.apk "build/app/outputs/flutter-apk/rolling-text-${VERSION}.apk"
           cp build/app/outputs/flutter-apk/app-debug.apk "build/app/outputs/flutter-apk/rolling-text-${VERSION}-debug.apk"
 
-      - name: Upload APKs to release
-        if: github.event_name == 'release'
+      - name: Extract this version's CHANGELOG section
+        if: startsWith(github.ref, 'refs/tags/')
+        id: changelog
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          gh release upload "$GITHUB_REF_NAME" \
-            "build/app/outputs/flutter-apk/rolling-text-${VERSION}.apk" \
-            "build/app/outputs/flutter-apk/rolling-text-${VERSION}-debug.apk" \
-            --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          version="${GITHUB_REF_NAME#v}"
+          # Take everything between this version's heading and the next one.
+          body=$(awk "/^## \[$version\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+          # Trim leading and trailing blank lines, and the trailing --- separator.
+          body=$(printf '%s\n' "$body" | sed -e '/./,$!d' -e 's/^---$//' | sed -e :a -e '/^\n*$/{$d;N;ba}')
+          if [ -z "$(printf '%s' "$body" | tr -d '[:space:]')" ]; then
+            echo "CHANGELOG.md has no section for [$version]." >&2
+            echo "Refusing to publish a release with empty notes -- add the section and re-tag." >&2
+            exit 1
+          fi
+          printf 'body<<CHANGELOG_EOF\n%s\nCHANGELOG_EOF\n' "$body" >> "$GITHUB_OUTPUT"
+
+      # generate_release_notes appends GitHub's "What's Changed" PR list below `body`.
+      # Using `gh release create --notes` instead would replace the whole body and drop
+      # that list, which is how gencon-audiobook shipped two releases without it.
+      - name: Create the release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          body: ${{ steps.changelog.outputs.body }}
+          generate_release_notes: true
+          files: |
+            build/app/outputs/flutter-apk/rolling-text-*.apk
 
       - name: Upload APKs as artifacts
         if: github.event_name == 'workflow_dispatch'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to Rolling Text will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> Bullets in this file are single unbroken lines on purpose. GitHub's release renderer preserves mid-bullet newlines as visible line breaks instead of reflowing them, so a hard-wrapped bullet publishes as broken release notes.
+
+## [Unreleased]
+
+## [0.5.0] - 2026-07-30
+
+### Keyboard Accessibility Release
+
+Every settings sheet can now be driven without a mouse. Version 0.4.0 was only ever tagged as `v0.4.0-beta.1` and never released, so the changes staged for it are included here.
+
+### Added
+- **Keyboard operation of every settings sheet** - Arrow keys move between themes and fonts, Enter applies the focused choice, and Escape closes the sheet
+- **Focus opens on the active row** - The theme and font sheets focus the current selection when they open, so arrow keys navigate from where you already are rather than from the top of the list
+- **Off-screen selection is revealed** - The font sheet scrolls an active font that sits below the fold into view when it opens, since a row that is never built can neither be seen nor take keyboard focus
+- **Keyboard scrolling in About** - The About text scrolls with the arrow and page keys, all the way to the end of the content
+- **Immediately typeable font size** - The Font Size sheet opens with its numeric field focused and preselected, with the slider one Tab away
+- **Screen reader support for the character counter** - The counter is announced as "N of M characters used" instead of being hidden from assistive technology
+- **Release signing and CI builds** - Tagged releases produce signed release and debug APKs
+- **Unit tests for the rolling truncation logic** - Including Unicode and emoji boundary cases
+
+### Changed
+- **Reducing the character limit no longer asks for confirmation** - A lower limit applies immediately and the oldest characters are removed; that text is not recoverable
+- **Font size preview is a true preview** - The Font Size sheet previews live while open; Apply commits it, while Cancel, Escape, the close button and a barrier tap all revert to the size the sheet opened with
+- **Validation errors are inline** - Out-of-range values in the Character Limit and Font Size sheets are reported beneath the field and keep the sheet open, replacing the modal error dialogs. No dialogs remain anywhere in the app
+- **Font size is entered in the sheet itself** - A single field accepts any size from 6pt to 999pt, replacing the separate "Enter custom size" button and the second sheet it opened
+- **Bottom sheets have a visible edge** - Sheets are painted on a distinct surface so they separate from the editor in every theme
+- **Character count no longer rebuilds the whole screen** - Counting flows through a `ValueNotifier` rather than an empty `setState` on every keystroke
+
+### Fixed
+- **Android release builds could not download uncached Google Fonts** - A fresh install could not apply most fonts in the picker
+- **Editor stopped accepting keystrokes after closing a sheet on Web** - Dismissing any bottom sheet left the browser with no focused input element, and only a page reload recovered it
+- **Theme and font could not be selected with arrow keys on Web** - Flutter binds bare arrows to scrolling rather than focus traversal on Web, so the theme sheet ignored them entirely and the font sheet scrolled without moving the selection
+- **Picker sheets opened with focus outside the sheet on Web** - Focus stayed on the toolbar button behind the modal barrier instead of moving into the sheet
+- **About text could not be scrolled to its end with the keyboard** - The focus anchor it relied on was unmounted once it scrolled beyond the list's cache extent
+- **Out-of-range values could be committed** - The Character Limit and Font Size sheets now only accept values inside their valid range
+- **Font size wrote to disk on every drag tick** - The new size is saved once, when the sheet closes
+- **Duplicate hint text on focus** - The editor no longer showed a second hint in a different font
+
+### Known Issues
+- **iOS is untested on hardware** - It takes the same code path as Android, which was verified on a Pixel 8 Pro
+- **Editor can lose text input** - Tapping empty space or switching windows can leave the editor unable to accept typing until the page is reloaded ([#29](https://github.com/XeroIP/rolling-text/issues/29))
+
+---
+
 ## [0.3.0] - 2026-02-28
 
 ### Complete Rewrite in Flutter

--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ flutter build web                        # Web
 
 Download the latest APK from the [Releases](https://github.com/XeroIP/rolling-text/releases) page.
 
+## Releasing
+
+Releases are cut from tags. [`CHANGELOG.md`](CHANGELOG.md) is the single source of truth for what a release says.
+
+1. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`. Keep every bullet on one unbroken line — GitHub's release renderer turns mid-bullet newlines into visible line breaks instead of reflowing them.
+2. Set the matching version in `pubspec.yaml`, incrementing the build number after the `+` as well. Android refuses to install an APK whose build number is not higher than the installed one.
+3. Tag and push:
+
+    ```bash
+    git tag v0.5.0
+    git push origin v0.5.0
+    ```
+
+The `Build and release` workflow then runs the tests, builds signed release and debug APKs, and publishes a GitHub release whose notes are that CHANGELOG section followed by the auto-generated list of merged pull requests, with both APKs attached.
+
+It fails the release rather than publishing something wrong if the tag does not match `pubspec.yaml`, or if `CHANGELOG.md` has no section for that version.
+
+To build APKs without releasing, run the workflow manually from the Actions tab (`Actions > Build and release > Run workflow`); the APKs are uploaded as build artifacts instead.
+
 ## Technical Details
 
 - **Platforms**: Android, iOS, Web

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: rolling_text
 description: "A rolling character limit text app. Write your thoughts and let them go."
 publish_to: 'none'
 
-version: 0.4.0+1
+version: 0.5.0+2
 
 environment:
   sdk: ^3.10.4


### PR DESCRIPTION
Brings `CHANGELOG.md` current and makes releases a single tag push.

Closes #32

## Changelog

Documents **0.5.0**, covering the keyboard accessibility work plus the changes staged for
0.4.0. That version was only ever tagged `v0.4.0-beta.1` and never released, so folding it
into 0.5.0 avoids documenting a release that does not exist. Adds an `[Unreleased]`
section, and records in the file why bullets are single unbroken lines — GitHub's release
renderer turns mid-bullet newlines into visible line breaks instead of reflowing them.

## Workflow

`build-release.yml` moves from `release: [published]` to tag pushes and creates the
release itself.

**These cannot be two workflows.** GitHub does not start a new workflow run from an event
raised by the default `GITHUB_TOKEN`, so a tag-triggered job that created the release
would leave an `on: release` job unfired and publish releases with no APKs — a failure
you would only notice after cutting one.

Release notes are the CHANGELOG section for the tag, with `generate_release_notes: true`
appending the merged-PR list beneath it. Passing `gh release create --notes` instead
replaces the entire body and drops that list, which is how gencon-audiobook shipped
v0.1.5 and v0.1.6 without it.

Two guards, since both failures are otherwise silent:
- the tag must match `pubspec.yaml`, or the APK filename and the version shown in the app disagree;
- the version must have a CHANGELOG section, rather than publishing empty notes.

Also fixes a latent bug: the rename step derived the version from `GITHUB_REF_NAME`, which
on `workflow_dispatch` is a branch name — a branch like `build/foo` produced a path with a
slash and failed the copy. It now reads `pubspec.yaml`, which the guard keeps in agreement
with the tag.

## Version

`pubspec.yaml` goes to **0.5.0+2**. The build number has to advance or Android refuses to
install over an existing `0.4.0+1`.

## Testing

- CHANGELOG extraction run locally against `0.5.0` (35 lines, correctly bounded, `---` stripped), `0.3.0` (27 lines), and a nonexistent version (empty, so the release fails).
- Version guard checked: `v0.5.0` passes, `v0.4.0` is rejected.
- Workflow YAML parsed and step conditions confirmed.
- `flutter analyze` clean, 53 tests passing.

The workflow itself cannot be exercised without pushing a tag, so the first real release is
also its first live run. The guards fail closed, so a mistake blocks the release rather than
publishing a broken one.

## Reviewer note

Tests now run before a release build. That is new — there was no CI test gate before — so a
failing test will block a release rather than shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)