### PR TITLE
fix(ci): pin the Flutter version to 3.44.8

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: 3.44.8
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: 3.44.8
 
       - name: Install dependencies
         run: flutter pub get

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Try it in your browser at https://xeroip.github.io/rolling-text/
 
 ### Run from source
 
+Requires Flutter 3.44.8. CI is pinned to this version; a different local Flutter will
+resolve `pubspec.lock` differently and rewrite it on `flutter pub get`.
+
 1. Clone the repository:
 
     ```bash

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -196,10 +196,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -212,10 +212,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -449,10 +449,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Both `subosito/flutter-action@v2` steps requested `channel: stable` with no `flutter-version`, so CI built against whatever stable happened to be that day and local Flutter (3.38.5) drifted from it -- rewriting four SDK-pinned transitive packages (`characters`, `matcher`, `material_color_utilities`, `test_api`) in `pubspec.lock` on every local `pub get`.
- Pin both workflows to `flutter-version: 3.44.8`, the version CI has actually been building releases with (confirmed: today's v0.5.0 APKs and web deploy both ran on 3.44.8). Upgraded local Flutter to match rather than regressing CI to the stale local version.
- Regenerated `pubspec.lock` under 3.44.8; a second `pub get` now produces no diff.
- Noted the required Flutter version in the README's "Run from source" section.

## Test plan
- [x] `flutter analyze` clean on 3.44.8
- [x] `flutter test` -- all 4 suites green after `flutter clean` (two transient failures traced to a stale pre-upgrade shader cache, not app code; disappeared after clean)
- [x] `flutter pub get` run twice in a row produces no further `pubspec.lock` diff
- [ ] Manually trigger `Build and release` via `workflow_dispatch` on this branch to confirm 3.44.8 installs and builds cleanly in CI (safe: skips release creation, uploads APKs as artifacts only)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)