### PR TITLE
fix(editor): restore text input after tapping outside or window blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Typed text is no longer offered to the Android keyboard** - The editor opts out of IME personalized learning, so what you type is not added to your keyboard's dictionary or typing history
+
+### Fixed
+- **Editor stopped accepting keystrokes after tapping empty space or leaving the window** - Tapping away from the editor or switching to another window and back left typing dead until the page was reloaded
+
 ## [0.5.0] - 2026-07-30
 
 ### Keyboard Accessibility Release

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Lowering the limit below what you have already written removes the oldest charac
 - **Themes** - Light, Dark, and Sepia
 - **Font picker** - Choose from 20 curated Google Fonts, or Source Code Pro as the default. Uncached fonts require an internet connection on first use.
 - **Adjustable font size** - Type any size from 6pt to 999pt, or drag the slider for 6pt to 144pt
-- **Keyboard operation** - Every settings sheet works without a mouse: arrow keys move between themes and fonts, Enter applies, Escape closes, and arrow or page keys scroll the About text. Focus returns to the editor when a sheet closes.
+- **Keyboard operation** - Every settings sheet works without a mouse: arrow keys move between themes and fonts, Enter applies, Escape closes, and arrow or page keys scroll the About text. Focus returns to the editor when a sheet closes, when you tap elsewhere in the app, or when you switch back to the app after leaving it.
 - **Settings persistence** - Character limit, theme, font, and font size are saved between sessions. Text is never saved.
+- **Private by default on Android** - The editor opts out of IME personalized learning, so what you type is not added to your keyboard's dictionary or typing history
 - **Unicode and emoji support** - Handles multi-byte characters correctly
 
 ## Installation

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -49,6 +49,7 @@ class _MainScreenState extends State<MainScreen> {
   final ValueNotifier<int> _charCount = ValueNotifier<int>(0);
   bool _isEnforcing = false;
   String _version = '';
+  late final AppLifecycleListener _lifecycleListener;
 
   @override
   void initState() {
@@ -56,10 +57,19 @@ class _MainScreenState extends State<MainScreen> {
     PackageInfo.fromPlatform().then((info) {
       setState(() => _version = info.version);
     });
+    // Returning to the app (another window regains focus, or the OS resumes
+    // the app on mobile) does not by itself give the editor focus back. Left
+    // alone, that reproduces the same dead-input state as #29's tap-outside
+    // case: the FocusNode can still report focused while nothing is actually
+    // listening for keystrokes.
+    _lifecycleListener = AppLifecycleListener(
+      onResume: () => _editorFocusNode.requestFocus(),
+    );
   }
 
   @override
   void dispose() {
+    _lifecycleListener.dispose();
     _editorFocusNode.dispose();
     _controller.dispose();
     _charCount.dispose();
@@ -182,6 +192,21 @@ class _MainScreenState extends State<MainScreen> {
                           controller: _controller,
                           focusNode: _editorFocusNode,
                           onChanged: (text) => _onTextChanged(text, settings),
+                          // The default TapRegion behaviour unfocuses the field
+                          // on an outside tap. That is #29: nothing ever
+                          // requests focus again afterward, so typing goes
+                          // nowhere until the page reloads. Re-requesting focus
+                          // here instead keeps the editor the permanent target
+                          // for keystrokes, which matches an app with no other
+                          // text input to tap into.
+                          onTapOutside: (_) => _editorFocusNode.requestFocus(),
+                          // "Nothing is saved. Nothing is stored" is the whole
+                          // premise of this app; leaving IME personalized
+                          // learning on would let the keyboard itself add typed
+                          // text to its dictionary and suggestion history. This
+                          // opts out of that without touching autocorrect or
+                          // suggestions, which are a separate decision.
+                          enableIMEPersonalizedLearning: false,
                           maxLines: null,
                           expands: true,
                           textAlignVertical: TextAlignVertical.top,

--- a/test/framework_assumptions_test.dart
+++ b/test/framework_assumptions_test.dart
@@ -11,7 +11,8 @@
 // Flutter upgrade, the fix is to add the corresponding behaviour back to
 // main_screen.dart -- not to delete the test.
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart'
+    show debugDefaultTargetPlatformOverride, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -211,6 +212,49 @@ void main() {
     expect(shortcutFired, 1, reason: 'sheet-level Enter fires regardless of focus');
     expect(submitted, 0, reason: 'onSubmitted comes from the platform action, not a raw key');
   });
+
+  testWidgets(
+    'a bare TextField unfocuses itself on an outside tap on desktop platforms',
+    (tester) async {
+      // This is the framework default #29's fix works around: EditableText's
+      // built-in TapRegion unfocuses on an outside tap on desktop platforms
+      // (and, separately, on Web) unless onTapOutside is overridden. The
+      // editor in main_screen.dart supplies its own onTapOutside specifically
+      // to prevent this. If a future SDK stops unfocusing here by default,
+      // that override becomes redundant -- but harmless, so prefer leaving it
+      // rather than deleting this test.
+      // Reset before the test ends, not via addTearDown: flutter_test checks
+      // this debug variable is back to its original value immediately after
+      // the test body returns, which runs before addTearDown callbacks fire.
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      try {
+        debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  TextField(focusNode: focusNode, autofocus: true),
+                  const SizedBox(height: 200, child: Text('elsewhere')),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(focusNode.hasFocus, isTrue);
+
+        await tester.tap(find.text('elsewhere'));
+        await tester.pumpAndSettle();
+
+        expect(focusNode.hasFocus, isFalse);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    },
+  );
 
   testWidgets('focus traversal reaches and reveals off-screen tiles', (
     tester,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show debugDefaultTargetPlatformOverride;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -105,6 +106,48 @@ void main() {
     expect(find.text('Start typing…'), findsNothing);
     expect(tester.getSize(find.byType(TextField).first).width, greaterThan(700));
   });
+
+  testWidgets('the editor opts out of IME personalized learning', (tester) async {
+    await _pumpMainScreen(tester);
+
+    final editor = tester.widget<TextField>(find.byType(TextField).first);
+    expect(editor.enableIMEPersonalizedLearning, isFalse);
+  });
+
+  testWidgets(
+    'tapping outside the editor on desktop keeps it focused and typeable',
+    (tester) async {
+      // The framework's own default here unfocuses the field -- see
+      // framework_assumptions_test.dart. This proves main_screen.dart's
+      // onTapOutside override replaces that default rather than merely
+      // supplementing it.
+      //
+      // Reset before the test ends, not via addTearDown: flutter_test checks
+      // this debug variable is back to its original value immediately after
+      // the test body returns, which runs before addTearDown callbacks fire.
+      try {
+        debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+
+        await _pumpMainScreen(tester);
+        final editor = find.byType(TextField).first;
+        final focusNode = tester.widget<TextField>(editor).focusNode!;
+        expect(focusNode.hasFocus, isTrue);
+
+        // A point inside the Scaffold's padding band, outside the editor's
+        // own bounds and off every toolbar button.
+        await tester.tapAt(const Offset(5, 5));
+        await tester.pumpAndSettle();
+
+        expect(focusNode.hasFocus, isTrue);
+
+        await tester.enterText(editor, 'still typeable');
+        await tester.pump();
+        expect(find.text('still typeable'), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    },
+  );
 
   group('numeric sheets are usable from the keyboard alone', () {
     testWidgets('character limit preselects its value so typing replaces it', (


### PR DESCRIPTION
## Summary
- Fixes #29: the editor permanently stopped accepting keystrokes after tapping empty space or switching windows and back, recoverable only by reload. Root cause was two Flutter defaults: `TextField`'s `TapRegion` unfocuses on an outside tap on desktop platforms, and `autofocus: true` only fires once at mount, so nothing ever re-requested focus afterward.
- Overrides `onTapOutside` on the editor to re-request its `FocusNode` instead of unfocusing, and adds an `AppLifecycleListener` that does the same on resume, covering the window-blur-and-return path.
- Fixes #23: disables Android IME personalized learning on the editor field, so typed text is not added to the keyboard's dictionary or typing history -- closing a gap against the app's "nothing is saved, nothing is stored" promise.
- Adds regression tests: a widget test proving typing survives a tap outside on desktop platforms, a widget test asserting the IME opt-out is configured, and a framework-assumptions test pinning the default `onTapOutside` unfocus behaviour this fix works around.
- Updates README (keyboard-operation and privacy bullets) and CHANGELOG (`## [Unreleased]`).

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` -- all 56 tests green
- [x] Manual browser verification in Chrome: typed text, clicked empty canvas, typed again -- still landed. Switched to another tab and back, typed again -- still landed.
- [x] Regression check: opened and closed all five sheets (limit, theme, font, font size, about) with Escape -- editor remained typeable after each, confirming `_restoreEditorFocus()` still works alongside the new `onTapOutside` override.

Closes #29
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)