### PR TITLE
fix(settings): validate persisted preferences and surface write failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Editor stopped accepting keystrokes after tapping empty space or leaving the window** - Tapping away from the editor or switching to another window and back left typing dead until the page was reloaded
+- **Corrupt or out-of-range saved settings could crash the app on launch** - Settings are now validated when they load, and anything invalid falls back to its default instead of throwing
+- **A setting that failed to save appeared to have been saved** - A failed write now warns that the change will not be remembered, rather than silently leaving the app and storage disagreeing
 
 ## [0.5.0] - 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Lowering the limit below what you have already written removes the oldest charac
 - **Font picker** - Choose from 20 curated Google Fonts, or Source Code Pro as the default. Uncached fonts require an internet connection on first use.
 - **Adjustable font size** - Type any size from 6pt to 999pt, or drag the slider for 6pt to 144pt
 - **Keyboard operation** - Every settings sheet works without a mouse: arrow keys move between themes and fonts, Enter applies, Escape closes, and arrow or page keys scroll the About text. Focus returns to the editor when a sheet closes, when you tap elsewhere in the app, or when you switch back to the app after leaving it.
-- **Settings persistence** - Character limit, theme, font, and font size are saved between sessions. Text is never saved.
+- **Settings persistence** - Character limit, theme, font, and font size are saved between sessions. Text is never saved. Saved values are validated on load and fall back to defaults if storage is corrupt or out of range. A setting that fails to save still applies for the session, with a warning that it won't be remembered.
 - **Private by default on Android** - The editor opts out of IME personalized learning, so what you type is not added to your keyboard's dictionary or typing history
 - **Unicode and emoji support** - Handles multi-byte characters correctly
 

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -3,6 +3,40 @@ import '../theme/app_theme.dart';
 
 const int defaultMaxChars = 128;
 
+// Bounds a saved value must fall inside to be trusted on load. These mirror
+// the ranges the settings sheets themselves enforce in main_screen.dart --
+// keep both in sync if either changes.
+const int minMaxChars = 1;
+const int maxMaxChars = 1000000;
+const double minFontSize = 6;
+const double maxFontSize = 999; // The numeric field's range, not the slider's
+// (6-144). Clamping to the slider's max would shrink a legitimately saved
+// larger size on load.
+
+/// Curated list of 20 Google Fonts, sorted alphabetically.
+const List<String> availableFonts = [
+  'Courier Prime',
+  'Crimson Text',
+  'EB Garamond',
+  'Fira Code',
+  'IBM Plex Mono',
+  'Inconsolata',
+  'Inter',
+  'JetBrains Mono',
+  'Karla',
+  'Lato',
+  'Libre Baskerville',
+  'Lora',
+  'Merriweather',
+  'Nunito',
+  'Open Sans',
+  'Playfair Display',
+  'PT Serif',
+  'Raleway',
+  'Source Code Pro',
+  'Work Sans',
+];
+
 class AppSettings extends ChangeNotifier {
   int _maxChars = defaultMaxChars;
   AppTheme _theme = AppTheme.light;

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -9,31 +9,6 @@ import '../services/preferences_service.dart';
 import '../theme/app_theme.dart';
 import '../utils/text_truncation.dart';
 
-
-/// Curated list of 20 Google Fonts, sorted alphabetically.
-const List<String> availableFonts = [
-  'Courier Prime',
-  'Crimson Text',
-  'EB Garamond',
-  'Fira Code',
-  'IBM Plex Mono',
-  'Inconsolata',
-  'Inter',
-  'JetBrains Mono',
-  'Karla',
-  'Lato',
-  'Libre Baskerville',
-  'Lora',
-  'Merriweather',
-  'Nunito',
-  'Open Sans',
-  'Playfair Display',
-  'PT Serif',
-  'Raleway',
-  'Source Code Pro',
-  'Work Sans',
-];
-
 class MainScreen extends StatefulWidget {
   final PreferencesService prefsService;
 
@@ -294,6 +269,21 @@ class _MainScreenState extends State<MainScreen> {
     );
   }
 
+  /// Awaits a preference write and warns if it silently failed.
+  ///
+  /// The setting stays applied for this session either way -- reverting the
+  /// UI back to its old value on a storage failure would be a worse
+  /// experience than a value that just does not survive to the next launch.
+  /// PreferencesService's save methods report success or failure instead of
+  /// being fire-and-forget specifically so this can tell the difference.
+  Future<void> _persist(Future<bool> Function() save, BuildContext context) async {
+    final saved = await save();
+    if (saved || !context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text("This change won't be remembered")),
+    );
+  }
+
   Future<void> _showLimitDialog(BuildContext context, AppSettings settings) async {
     final newLimit = await _showSheet<int>(
       isScrollControlled: true,
@@ -301,13 +291,14 @@ class _MainScreenState extends State<MainScreen> {
         title: 'Character Limit',
         hintText: '1 – 1,000,000',
         initialValue: settings.maxChars,
-        minValue: 1,
-        maxValue: 1000000,
+        minValue: minMaxChars,
+        maxValue: maxMaxChars,
         errorMessage: 'Please enter a number between 1 and 1,000,000',
         colors: colorsFor(settings.theme),
       ),
     );
-    if (newLimit != null) _applyNewLimit(newLimit, settings);
+    if (!context.mounted) return;
+    if (newLimit != null) _applyNewLimit(newLimit, settings, context);
     await _restoreEditorFocus();
   }
 
@@ -317,9 +308,9 @@ class _MainScreenState extends State<MainScreen> {
   /// text disappear, so asking permission to shorten it works against the point.
   /// _onTextChanged truncates when the text is over the limit and does nothing
   /// when it is not, so one call covers both cases.
-  void _applyNewLimit(int newLimit, AppSettings settings) {
+  void _applyNewLimit(int newLimit, AppSettings settings, BuildContext context) {
     settings.setMaxChars(newLimit);
-    widget.prefsService.saveMaxChars(newLimit);
+    _persist(() => widget.prefsService.saveMaxChars(newLimit), context);
     _onTextChanged(_controller.text, settings);
   }
 
@@ -374,8 +365,8 @@ class _MainScreenState extends State<MainScreen> {
                   trailing: settings.theme == theme ? const Icon(Icons.check) : null,
                   onTap: () {
                     settings.setTheme(theme);
-                    widget.prefsService.saveTheme(theme);
                     Navigator.pop(ctx);
+                    _persist(() => widget.prefsService.saveTheme(theme), context);
                   },
                 );
               }),
@@ -430,8 +421,8 @@ class _MainScreenState extends State<MainScreen> {
                   selectedFamily: settings.fontFamily,
                   onSelected: (family) {
                     settings.setFontFamily(family);
-                    widget.prefsService.saveFontFamily(family);
                     Navigator.pop(ctx);
+                    _persist(() => widget.prefsService.saveFontFamily(family), context);
                   },
                 ),
               ),
@@ -457,8 +448,9 @@ class _MainScreenState extends State<MainScreen> {
         colors: colorsFor(settings.theme),
       ),
     );
+    if (!context.mounted) return;
     if (applied != true) settings.setFontSize(originalSize);
-    widget.prefsService.saveFontSize(settings.fontSize);
+    _persist(() => widget.prefsService.saveFontSize(settings.fontSize), context);
     await _restoreEditorFocus();
   }
 
@@ -927,7 +919,7 @@ class _FontSizeSheetState extends State<_FontSizeSheet> {
   // typing a number one digit at a time.
   void _onFieldChanged(String text) {
     final value = int.tryParse(text);
-    if (value != null && value >= 6 && value <= 999) {
+    if (value != null && value >= minFontSize && value <= maxFontSize) {
       setState(() {
         _error = null;
         _size = value.toDouble();
@@ -943,7 +935,7 @@ class _FontSizeSheetState extends State<_FontSizeSheet> {
   void _apply() {
     if (_closing) return;
     final value = int.tryParse(_controller.text);
-    if (value == null || value < 6 || value > 999) {
+    if (value == null || value < minFontSize || value > maxFontSize) {
       setState(() => _error = 'Enter a size between 6 and 999 pt');
       _focusNode.requestFocus();
       _selectAll();

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -17,25 +17,62 @@ class PreferencesService {
     return PreferencesService(prefs);
   }
 
+  /// Loads settings from storage, validating every value first.
+  ///
+  /// `getInt`/`getDouble`/`getString` do an unchecked cast to the requested
+  /// type internally and throw on a mismatch (see the shared_preferences
+  /// source), so a value written by a different type -- corrupted storage, a
+  /// hand-edited web LocalStorage entry, a future version that changes a
+  /// key's type -- would crash startup before the first frame. Reading
+  /// through [SharedPreferences.get], which returns the untyped value with no
+  /// cast, lets a bad value fall back to its default instead.
   void loadInto(AppSettings settings) {
     settings.loadFrom(
-      maxChars: _prefs.getInt(_keyMaxChars) ?? defaultMaxChars,
-      theme: AppThemeExtension.fromKey(_prefs.getString(_keyTheme) ?? 'light'),
-      fontFamily: _prefs.getString(_keyFontFamily),
-      fontSize: _prefs.getDouble(_keyFontSize) ?? 16.0,
+      maxChars: _validMaxChars(_prefs.get(_keyMaxChars)),
+      theme: AppThemeExtension.fromKey(_validThemeKey(_prefs.get(_keyTheme))),
+      fontFamily: _validFontFamily(_prefs.get(_keyFontFamily)),
+      fontSize: _validFontSize(_prefs.get(_keyFontSize)),
     );
   }
 
-  Future<void> saveMaxChars(int value) => _prefs.setInt(_keyMaxChars, value);
+  // AppThemeExtension.fromKey already falls back to light for any string it
+  // does not recognise; this only needs to guard against a non-String value
+  // reaching it in the first place.
+  String _validThemeKey(Object? stored) => stored is String ? stored : 'light';
 
-  Future<void> saveTheme(AppTheme value) =>
+  int _validMaxChars(Object? stored) {
+    if (stored is! int || stored < minMaxChars || stored > maxMaxChars) {
+      return defaultMaxChars;
+    }
+    return stored;
+  }
+
+  double _validFontSize(Object? stored) {
+    if (stored is! double || stored < minFontSize || stored > maxFontSize) {
+      return 16.0;
+    }
+    return stored;
+  }
+
+  /// Unknown font names -- from a hand-edited value, or a font retired from
+  /// [availableFonts] in a future release -- fall back to the app default
+  /// (null selects Source Code Pro) rather than being passed to
+  /// GoogleFonts.getFont, which throws for a name it does not recognise.
+  String? _validFontFamily(Object? stored) {
+    if (stored is! String || !availableFonts.contains(stored)) return null;
+    return stored;
+  }
+
+  Future<bool> saveMaxChars(int value) => _prefs.setInt(_keyMaxChars, value);
+
+  Future<bool> saveTheme(AppTheme value) =>
       _prefs.setString(_keyTheme, value.key);
 
-  Future<void> saveFontFamily(String? value) {
+  Future<bool> saveFontFamily(String? value) {
     if (value == null) return _prefs.remove(_keyFontFamily);
     return _prefs.setString(_keyFontFamily, value);
   }
 
-  Future<void> saveFontSize(double value) =>
+  Future<bool> saveFontSize(double value) =>
       _prefs.setDouble(_keyFontSize, value);
 }

--- a/test/preferences_service_test.dart
+++ b/test/preferences_service_test.dart
@@ -1,0 +1,139 @@
+// Regression coverage for #19: preferences load with no type, range, or
+// allow-list guarding, so corrupt or hand-edited storage crashes startup.
+//
+// getInt/getDouble/getString in shared_preferences do an unchecked cast to
+// the requested type and throw on a mismatch (see the package's own
+// SharedPreferencesStorePlatform-backed implementation). Seeding a wrong type
+// through SharedPreferences.setMockInitialValues reproduces that here: it
+// stores the value exactly as given, with no validation of its own.
+//
+// These test loadInto() directly rather than through MainScreen. MainScreen's
+// test harness (widget_test.dart's _pumpMainScreen) never calls loadInto -- it
+// builds AppSettings from explicit theme/fontFamily parameters -- so it cannot
+// observe this behaviour at all.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rolling_text/models/app_settings.dart';
+import 'package:rolling_text/services/preferences_service.dart';
+import 'package:rolling_text/theme/app_theme.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<PreferencesService> _serviceWith(Map<String, Object> stored) async {
+  SharedPreferences.setMockInitialValues(stored);
+  final prefs = await SharedPreferences.getInstance();
+  return PreferencesService(prefs);
+}
+
+void main() {
+  test('valid stored values load unchanged', () async {
+    final service = await _serviceWith({
+      'maxCharacters': 500,
+      'theme': 'dark',
+      'fontFamily': 'Lora',
+      'fontSize': 24.0,
+    });
+    final settings = AppSettings();
+
+    service.loadInto(settings);
+
+    expect(settings.maxChars, 500);
+    expect(settings.theme, AppTheme.dark);
+    expect(settings.fontFamily, 'Lora');
+    expect(settings.fontSize, 24.0);
+  });
+
+  test('a wrong-typed maxCharacters falls back to the default instead of throwing', () async {
+    final service = await _serviceWith({'maxCharacters': 'not a number'});
+    final settings = AppSettings();
+
+    service.loadInto(settings);
+
+    expect(settings.maxChars, defaultMaxChars);
+  });
+
+  test('a wrong-typed fontSize falls back to the default instead of throwing', () async {
+    final service = await _serviceWith({'fontSize': 'not a number'});
+    final settings = AppSettings();
+
+    service.loadInto(settings);
+
+    expect(settings.fontSize, 16.0);
+  });
+
+  test('a wrong-typed theme falls back to light instead of throwing', () async {
+    final service = await _serviceWith({'theme': 12345});
+    final settings = AppSettings();
+
+    service.loadInto(settings);
+
+    expect(settings.theme, AppTheme.light);
+  });
+
+  test('an out-of-range maxCharacters falls back to the default', () async {
+    final tooLow = await _serviceWith({'maxCharacters': 0});
+    final tooHigh = await _serviceWith({'maxCharacters': 2000000});
+
+    final lowSettings = AppSettings();
+    final highSettings = AppSettings();
+    tooLow.loadInto(lowSettings);
+    tooHigh.loadInto(highSettings);
+
+    expect(lowSettings.maxChars, defaultMaxChars);
+    expect(highSettings.maxChars, defaultMaxChars);
+  });
+
+  test('an out-of-range fontSize falls back to the default', () async {
+    final tooLow = await _serviceWith({'fontSize': 5.0});
+    final tooHigh = await _serviceWith({'fontSize': 9999.0});
+
+    final lowSettings = AppSettings();
+    final highSettings = AppSettings();
+    tooLow.loadInto(lowSettings);
+    tooHigh.loadInto(highSettings);
+
+    expect(lowSettings.fontSize, 16.0);
+    expect(highSettings.fontSize, 16.0);
+  });
+
+  test('a font size saved above the slider max but within the field range survives', () async {
+    // The slider only reaches 144; the numeric field accepts up to 999. A
+    // validator clamped to the slider's range would silently shrink a
+    // legitimately saved larger size on every future load.
+    final service = await _serviceWith({'fontSize': 200.0});
+    final settings = AppSettings();
+
+    service.loadInto(settings);
+
+    expect(settings.fontSize, 200.0);
+  });
+
+  test('an unknown font family falls back to the app default instead of crashing font resolution', () async {
+    final service = await _serviceWith({'fontFamily': 'Not A Real Font'});
+    final settings = AppSettings();
+
+    service.loadInto(settings);
+
+    expect(settings.fontFamily, isNull);
+  });
+
+  test('a wrong-typed font family falls back to the app default', () async {
+    final service = await _serviceWith({'fontFamily': 42});
+    final settings = AppSettings();
+
+    service.loadInto(settings);
+
+    expect(settings.fontFamily, isNull);
+  });
+
+  test('no stored values load the same defaults as a fresh install', () async {
+    final service = await _serviceWith({});
+    final settings = AppSettings();
+
+    service.loadInto(settings);
+
+    expect(settings.maxChars, defaultMaxChars);
+    expect(settings.theme, AppTheme.light);
+    expect(settings.fontFamily, isNull);
+    expect(settings.fontSize, 16.0);
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,6 +9,27 @@ import 'package:rolling_text/screens/main_screen.dart';
 import 'package:rolling_text/services/preferences_service.dart';
 import 'package:rolling_text/theme/app_theme.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+// shared_preferences_platform_interface is a transitive dependency of
+// shared_preferences, not a direct one -- pulled in here only to fake a
+// failing write for #24's tests, not added as a project dependency.
+// ignore: depend_on_referenced_packages
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+/// A store whose writes all fail, for exercising #24's failure path.
+///
+/// Reads still work normally (backed by [InMemorySharedPreferencesStore]) so
+/// the app loads its usual defaults; only [setValue] and [remove] report
+/// failure, matching what a real disk-full or permission error looks like to
+/// the SharedPreferences API -- a `false` result, not a thrown exception.
+class _FailingSharedPreferencesStore extends InMemorySharedPreferencesStore {
+  _FailingSharedPreferencesStore.empty() : super.empty();
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) async => false;
+
+  @override
+  Future<bool> remove(String key) async => false;
+}
 
 /// Pumps the app the way [RollingTextApp] does, including the real
 /// [themeDataFor] theme. Tests that pump a bare MaterialApp silently get
@@ -17,8 +38,17 @@ Future<void> _pumpMainScreen(
   WidgetTester tester, {
   AppTheme theme = AppTheme.light,
   String? fontFamily,
+  bool failWrites = false,
 }) async {
-  SharedPreferences.setMockInitialValues({});
+  if (failWrites) {
+    // setMockInitialValues always installs a plain InMemorySharedPreferencesStore,
+    // so a failing store has to be wired in the same way it does internally,
+    // then SharedPreferences.getInstance() re-read against it.
+    SharedPreferencesStorePlatform.instance = _FailingSharedPreferencesStore.empty();
+    SharedPreferences.resetStatic();
+  } else {
+    SharedPreferences.setMockInitialValues({});
+  }
   PackageInfo.setMockInitialValues(
     appName: 'Rolling Text',
     packageName: 'io.rollingtext.rolling_text',
@@ -719,6 +749,38 @@ void main() {
         reason: 'arrows must reach the end of the content, not stall partway',
       );
       expect(scrollable.position.maxScrollExtent, greaterThan(0));
+    });
+  });
+
+  group('preference writes are surfaced and reconciled', () {
+    testWidgets('a failed save keeps the change applied and warns it will not be remembered', (
+      tester,
+    ) async {
+      await _pumpMainScreen(tester, failWrites: true);
+      expect(_settings(tester).theme, AppTheme.light);
+
+      await tester.tap(find.byIcon(Icons.palette_outlined));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Dark'));
+      await tester.pumpAndSettle();
+
+      // The setting stays applied for the session even though it could not be
+      // saved -- fighting the UI back to its old value would be a worse
+      // experience than one that silently does not survive to next launch.
+      expect(_settings(tester).theme, AppTheme.dark);
+      expect(find.text("This change won't be remembered"), findsOneWidget);
+    });
+
+    testWidgets('a successful save shows no warning', (tester) async {
+      await _pumpMainScreen(tester);
+
+      await tester.tap(find.byIcon(Icons.palette_outlined));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Dark'));
+      await tester.pumpAndSettle();
+
+      expect(_settings(tester).theme, AppTheme.dark);
+      expect(find.text("This change won't be remembered"), findsNothing);
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixes #19: `shared_preferences`' `getInt`/`getDouble`/`getString` do an unchecked cast to the requested type and throw on a mismatch, so corrupted or hand-edited storage crashed startup before the first frame. `PreferencesService.loadInto` now reads through the untyped `get()` and validates each value -- type, range, and an allow-list for font family -- falling back to safe defaults instead.
- The validation bounds are lifted into named constants in `app_settings.dart` so the validator and the settings sheets share one source of truth. This caught a real bug in the draft of this change: the font size field's actual range is 6-999, not the slider's 6-144 -- clamping to the slider's max would have silently shrunk a legitimately saved larger size on every load.
- Fixes #24: all four preference writes were fire-and-forget, so a failed save left the UI showing a setting that was never persisted, with no signal. The `save*` methods now report success or failure instead of `Future<void>`, and each call site awaits the result: the change stays applied for the session either way (reverting it would be a worse experience than a value that just doesn't survive to next launch), but a failed write shows a SnackBar warning it won't be remembered.
- Adds `test/preferences_service_test.dart` -- unit tests against `PreferencesService.loadInto` directly, since the widget-level test harness never routes through it. Adds two widget tests for the write-failure path, using a fake `SharedPreferencesStorePlatform` whose writes always fail.
- Updates README (settings-persistence bullet) and CHANGELOG (`## [Unreleased]`).

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` -- all 65 tests green (53 existing + 10 new validation unit tests + 2 new write-failure widget tests)
- [x] Manually verified the constant lift didn't change behaviour: font size still accepts up to 999 in the field, slider still caps at 144

Closes #19
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)