### PR TITLE
build: cut 0.5.1 with composed notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-30
+
 ### Changed
 - **Typed text is no longer offered to the Android keyboard** - The editor opts out of IME personalized learning, so what you type is not added to your keyboard's dictionary or typing history
 
@@ -16,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Editor stopped accepting keystrokes after tapping empty space or leaving the window** - Tapping away from the editor or switching to another window and back left typing dead until the page was reloaded
 - **Corrupt or out-of-range saved settings could crash the app on launch** - Settings are now validated when they load, and anything invalid falls back to its default instead of throwing
 - **A setting that failed to save appeared to have been saved** - A failed write now warns that the change will not be remembered, rather than silently leaving the app and storage disagreeing
+
+### Known Issues
+- **iOS is untested on hardware** - It takes the same code path as Android, which was verified on a Pixel 8 Pro
+
+---
 
 ## [0.5.0] - 2026-07-30
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: rolling_text
 description: "A rolling character limit text app. Write your thoughts and let them go."
 publish_to: 'none'
 
-version: 0.5.0+2
+version: 0.5.1+3
 
 environment:
   sdk: ^3.10.4


### PR DESCRIPTION
## Summary
- Renames the accumulated `## [Unreleased]` entries (from #35 and #36) to `## [0.5.1] - 2026-07-30`, adds a fresh empty `Unreleased` above it, and adds a `---` separator before `## [0.5.0]` matching the file's existing convention.
- Adds a `### Known Issues` section carrying forward the still-true "iOS is untested on hardware" entry from 0.5.0. The other 0.5.0 Known Issue (#29's editor bug) is fixed in this release, so it is not carried forward.
- Bumps `pubspec.yaml` to `0.5.1+3`.
- No themed heading/summary (unlike 0.5.0) -- this is a four-item patch release with no unifying story, matching the bare-bullet style of 0.3.0 and the 0.2.x sections.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` -- all 68 tests green
- [x] Dry-ran the release workflow's changelog-extraction `awk`/`sed` locally against `## [0.5.1]` -- produces the expected non-empty body with the trailing `---` correctly stripped
- [ ] After merge: tag `v0.5.1` from `main` and confirm the `Build and release` workflow publishes signed APKs with these composed notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)