### PR TITLE
fix(settings): keep the Font Size sheet above the Android keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-07-30
+
+### Fixed
+- **Font Size sheet was hidden behind the keyboard on Android** - Opening it raised the numpad over the sheet, leaving the slider, the current size and the Cancel button unreachable; the sheet now stays above the keyboard and scrolls if a short screen cannot fit it
+
+### Known Issues
+- **iOS is untested on hardware** - It takes the same code path as Android, which was verified on a Pixel 8 Pro
+
+---
+
 ## [0.5.1] - 2026-07-30
 
 ### Changed

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -443,6 +443,12 @@ class _MainScreenState extends State<MainScreen> {
     // Only Apply (and the Enter that stands in for it) pops true.
     final originalSize = settings.fontSize;
     final applied = await _showSheet<bool>(
+      // Required because this sheet owns a text field whose autofocus raises
+      // the keyboard immediately. Without it the sheet is capped at 9/16 of
+      // the screen and laid out against the unreduced bottom edge, which put
+      // it entirely underneath the keyboard -- see the viewInsets padding in
+      // _FontSizeSheet.build. Both halves are needed; neither works alone.
+      isScrollControlled: true,
       builder: (ctx) => _FontSizeSheet(
         settings: settings,
         colors: colorsFor(settings.theme),
@@ -968,8 +974,21 @@ class _FontSizeSheetState extends State<_FontSizeSheet> {
         const SingleActivator(LogicalKeyboardKey.enter): _apply,
         const SingleActivator(LogicalKeyboardKey.numpadEnter): _apply,
       },
+      // Scrollable because this sheet is the tallest of the five: with the
+      // keyboard up on a short screen, the field, slider, scale labels and
+      // buttons together can exceed what is left. Scrolling degrades better
+      // than clipping the Apply button off the bottom.
+      child: SingleChildScrollView(
       child: Padding(
-      padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
+      // viewInsets.bottom lifts the sheet clear of the soft keyboard. The
+      // modal bottom sheet route does not do this for us -- it only clips to
+      // its layout box -- so a sheet with a focused field has to pad itself,
+      // exactly as _NumericSheet does. Pairs with isScrollControlled: true at
+      // the call site; without that this padding has no room to expand into.
+      padding: EdgeInsets.fromLTRB(
+        24, 16, 24,
+        MediaQuery.of(context).viewInsets.bottom + 32,
+      ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -1046,6 +1065,7 @@ class _FontSizeSheetState extends State<_FontSizeSheet> {
             ],
           ),
         ],
+      ),
       ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: rolling_text
 description: "A rolling character limit text app. Write your thoughts and let them go."
 publish_to: 'none'
 
-version: 0.5.1+3
+version: 0.5.2+4
 
 environment:
   sdk: ^3.10.4

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -752,6 +752,66 @@ void main() {
     });
   });
 
+  group('sheets with a text field stay above the soft keyboard', () {
+    // The bug these pin (#39) is invisible to every other test in this file:
+    // flutter_test has no soft keyboard and reports zero viewInsets, so a sheet
+    // laid out underneath the keyboard still satisfies findsOneWidget. Web and
+    // desktop have no soft keyboard either. Only a simulated inset plus a
+    // *geometric* assertion catches it, which is why these measure rendered
+    // bounds rather than checking the widget exists.
+    //
+    // tester.view.viewInsets is in physical pixels, hence the devicePixelRatio
+    // division to reason in the logical pixels getRect returns.
+    const double keyboardLogicalHeight = 300;
+
+    /// Raises a fake keyboard of [keyboardLogicalHeight] logical pixels and
+    /// returns the y coordinate of its top edge.
+    double simulateKeyboard(WidgetTester tester) {
+      final double dpr = tester.view.devicePixelRatio;
+      tester.view.viewInsets = FakeViewPadding(
+        bottom: keyboardLogicalHeight * dpr,
+      );
+      addTearDown(tester.view.resetViewInsets);
+      return tester.view.physicalSize.height / dpr - keyboardLogicalHeight;
+    }
+
+    testWidgets('the Font Size sheet does', (tester) async {
+      await _pumpMainScreen(tester);
+      final double keyboardTop = simulateKeyboard(tester);
+
+      await _openFontSize(tester);
+
+      // Apply is the bottom-most control in the sheet, so if it clears the
+      // keyboard the whole sheet does.
+      final applyBottom = tester.getRect(
+        find.widgetWithText(FilledButton, 'Apply'),
+      ).bottom;
+      expect(
+        applyBottom,
+        lessThanOrEqualTo(keyboardTop),
+        reason: 'the Font Size sheet must not be laid out under the keyboard',
+      );
+    });
+
+    testWidgets('the Character Limit sheet does', (tester) async {
+      await _pumpMainScreen(tester);
+      final double keyboardTop = simulateKeyboard(tester);
+
+      await tester.tap(find.byIcon(Icons.tune));
+      await tester.pumpAndSettle();
+
+      final applyBottom = tester.getRect(
+        find.widgetWithText(FilledButton, 'Apply'),
+      ).bottom;
+      expect(
+        applyBottom,
+        lessThanOrEqualTo(keyboardTop),
+        reason: 'this sheet already handled the keyboard correctly -- pin it '
+            'so it cannot regress the way the Font Size sheet did',
+      );
+    });
+  });
+
   group('preference writes are surfaced and reconciled', () {
     testWidgets('a failed save keeps the change applied and warns it will not be remembered', (
       tester,


### PR DESCRIPTION
## Summary
Fixes #39, found in Android UAT of v0.5.1. Opening the Font Size sheet raised the numpad over it, leaving the slider, the current size, and the Cancel button unreachable — only a blind type-and-submit worked. The sheet was mounted and autofocused the whole time; it was laid out against the unreduced bottom edge and clipped away.

`_FontSizeSheet` was the only text-field-bearing sheet missing **both** halves of Flutter's keyboard-avoidance pattern:

| Sheet | `isScrollControlled` | `viewInsets.bottom` padding |
|---|---|---|
| Character Limit (`_NumericSheet`) | yes | yes |
| Font picker / About | yes | n/a — no text field |
| Theme | no — correct, no text field | n/a |
| **Font Size** | **no** | **no** |

The framework does not compensate: `_ModalBottomSheetState.build` wraps the sheet in only a `ClipRect` and a layout delegate that caps height at `maxHeight * 9/16` when not scroll-controlled and positions the child at `size.height - childSize.height`. Nothing subtracts the keyboard — which is why `_NumericSheet` pads itself.

Also wraps the content in a `SingleChildScrollView`. This is the tallest of the five sheets, and with the keyboard up on a short screen the field, slider, scale labels, and buttons together overflow (reproduced as a 17px `RenderFlex` overflow once the sheet started laying out in the reduced space). Scrolling degrades better than clipping Apply off the bottom.

## Test plan
- [x] Reproduced the bug first on an Android emulator against unfixed `main` — sheet entirely absent with the numpad up, scrim still dimming
- [x] New regression tests **fail before the fix** (Apply's bottom edge at y=568 vs keyboard top at y=300) and pass after
- [x] Same test applied to the Character Limit sheet, which passed before and after — pinning the already-correct sheet against regressing the same way
- [x] `flutter analyze` clean; `flutter test` — all 70 pass
- [x] Verified on the emulator after the fix: sheet fully visible above the numpad, slider draggable (52pt, live preview applied), Cancel reverts correctly and returns focus to the editor
- [x] Character Limit sheet re-checked on device for regression — correct

Note the 15 existing Font Size sheet tests all passed while the sheet was invisible, because `flutter_test` reports zero `viewInsets` and web/desktop have no soft keyboard. The new tests simulate an inset and assert **rendered geometry** rather than widget existence.

Ships as **0.5.2** (`pubspec` bumped to `0.5.2+4`, CHANGELOG section added).

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)