### PR TITLE
build: 0.5.4 hygiene bundle (fail-closed signing, pinned CI actions, iOS doc fix)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,9 +17,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
           flutter-version: 3.44.8
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload APKs as artifacts
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: apks
           path: |

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -11,9 +11,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
           flutter-version: 3.44.8
@@ -25,7 +25,7 @@ jobs:
         run: flutter build web --release --base-href /rolling-text/
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: build/web

--- a/.github/workflows/policy-pinned-actions.yml
+++ b/.github/workflows/policy-pinned-actions.yml
@@ -1,0 +1,28 @@
+name: Policy - pinned actions
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Reject unpinned third-party actions
+        run: |
+          fail=0
+          while IFS=: read -r file line ref; do
+            action="${ref%@*}"
+            version="${ref##*@}"
+            version="${version%% *}"
+            if ! echo "$version" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "::error file=$file,line=$line::'$action' is pinned to '$version', not an immutable commit SHA"
+              fail=1
+            fi
+          done < <(grep -rnoE 'uses:\s*[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[A-Za-z0-9._-]+' .github/workflows --include='*.yml' | sed -E 's/uses:[[:space:]]*//')
+          exit "$fail"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-07-31
+
+### Fixed
+- **Release builds could silently sign with the debug keystore** - If `key.properties` was missing, Android release builds fell back to debug signing instead of failing, which would have produced a release artifact unable to receive normal upgrades from a properly-signed release; release builds now fail with a clear error instead, while debug and profile builds are unaffected
+- **Documented iOS minimum version overstated compatibility** - The README claimed iOS 12.0+ while the Xcode project's deployment target is 13.0; the badge now matches
+
+### Security
+- **Pinned third-party GitHub Actions to immutable commit SHAs** - Workflow actions previously floated on mutable version tags while the release workflow has write access and handles signing secrets; a new CI policy check now rejects any `uses:` reference that isn't pinned to a 40-character commit SHA
+
+### Known Issues
+- **iOS is untested on hardware** - It takes the same code path as Android, which was verified on a Pixel 8 Pro
+
+---
+
 ## [0.5.3] - 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rolling Text
 
 [![Android](https://img.shields.io/badge/Android-7.0%2B-green)](https://www.android.com)
-[![iOS](https://img.shields.io/badge/iOS-12.0%2B-blue)](https://www.apple.com/ios/)
+[![iOS](https://img.shields.io/badge/iOS-13.0%2B-blue)](https://www.apple.com/ios/)
 [![Web](https://img.shields.io/badge/Web-Chrome%2FSafari-orange)](https://github.com/XeroIP/rolling-text)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -47,13 +47,27 @@ android {
 
     buildTypes {
         release {
-            signingConfig = if (keystorePropertiesFile.exists()) {
-                signingConfigs.getByName("release")
-            } else {
-                // Fall back to debug signing if key.properties doesn't exist
-                signingConfigs.getByName("debug")
-            }
+            signingConfig = signingConfigs.getByName("release")
         }
+    }
+}
+
+// Configuration runs for every variant regardless of which task is invoked, so a debug
+// or profile build must not be blocked by a missing release keystore. Only fail once the
+// task graph is known to actually contain a release assemble/bundle task.
+gradle.taskGraph.whenReady {
+    val buildingRelease = allTasks.any {
+        it.name.startsWith("assembleRelease") || it.name.startsWith("bundleRelease")
+    }
+    if (buildingRelease && !keystorePropertiesFile.exists()) {
+        throw GradleException(
+            "Release build requested but android/key.properties is missing, so there is " +
+            "no release signing key to sign the APK/AAB with. Falling back to debug " +
+            "signing would produce a release artifact that can't receive normal upgrades " +
+            "from a properly-signed release. Create android/key.properties (see " +
+            "android/app/build.gradle.kts for the expected keys) or build a debug/profile " +
+            "variant instead."
+        )
     }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: rolling_text
 description: "A rolling character limit text app. Write your thoughts and let them go."
 publish_to: 'none'
 
-version: 0.5.3+5
+version: 0.5.4+6
 
 environment:
   sdk: ^3.10.4


### PR DESCRIPTION
## Summary
- Android release builds now fail closed with a clear error if `key.properties` is missing, instead of silently falling back to debug signing (#20)
- Every third-party GitHub Action in both workflows is pinned to an immutable commit SHA, plus a new CI policy job that rejects any future unpinned `uses:` reference (#21)
- README's iOS compatibility badge corrected from 12.0+ to 13.0+, matching the Xcode project's actual deployment target (#25)
- Cuts 0.5.4 with the composed CHANGELOG notes and version bump

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — all 73 tests pass
- [x] Verified locally: `assembleRelease` fails with the new error when `key.properties` is absent
- [x] Verified locally: `assembleRelease` succeeds when `key.properties` is present
- [x] Verified locally: `assembleDebug` succeeds regardless of `key.properties`
- [x] Dry-ran the CHANGELOG `[0.5.4]` section extraction the release workflow uses

Closes #20, Closes #21, Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)