### PR TITLE
chore: ignore .agents/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,8 @@ android/key.properties
 # Claude-specific
 .claude/
 
+# Antigravity agent-specific
+.agents/
+
 # Temporary files
 commit-message.txt


### PR DESCRIPTION
## Summary
- Adds `.agents/` (Antigravity agent-tooling directory) to `.gitignore`, mirroring the existing `.claude/` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)