### PR TITLE
fix: 0.5.6 -- Character Limit sheet showed the wrong maximum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6] - 2026-07-31
+
+### Fixed
+- **Character Limit sheet showed the wrong maximum** - Its hint text and validation error still said "1,000,000" after 0.5.5 lowered the real ceiling to 25,000; both now read from the same constant the app actually enforces
+
+### Known Issues
+- **iOS is untested on hardware** - It takes the same code path as Android, which was verified on a Pixel 8 Pro
+
+---
+
 ## [0.5.5] - 2026-07-31
 
 ### Changed

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -289,11 +289,11 @@ class _MainScreenState extends State<MainScreen> {
       isScrollControlled: true,
       builder: (ctx) => _NumericSheet(
         title: 'Character Limit',
-        hintText: '1 – 1,000,000',
+        hintText: '$minMaxChars – $maxMaxChars',
         initialValue: settings.maxChars,
         minValue: minMaxChars,
         maxValue: maxMaxChars,
-        errorMessage: 'Please enter a number between 1 and 1,000,000',
+        errorMessage: 'Please enter a number between $minMaxChars and $maxMaxChars',
         colors: colorsFor(settings.theme),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: rolling_text
 description: "A rolling character limit text app. Write your thoughts and let them go."
 publish_to: 'none'
 
-version: 0.5.5+7
+version: 0.5.6+8
 
 environment:
   sdk: ^3.10.4

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -346,7 +346,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        find.text('Please enter a number between 1 and 1,000,000'),
+        find.text('Please enter a number between $minMaxChars and $maxMaxChars'),
         findsOneWidget,
         reason: 'the error is inline, matching the Font Size sheet',
       );


### PR DESCRIPTION
## Summary
- The Character Limit sheet's hint text and validation error hardcoded "1,000,000" as literal strings; #18 (shipped in 0.5.5) lowered the real enforced ceiling to 25,000 but never updated these, so users saw the wrong maximum in both places
- Both now interpolate `minMaxChars`/`maxMaxChars` directly, so they can't drift out of sync with the enforced limit again
- Cuts 0.5.6 with the composed CHANGELOG notes and version bump

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` -- all 75 tests pass, including the updated assertion on the error message text
- [x] Dry-ran the CHANGELOG `[0.5.6]` section extraction the release workflow uses

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)