### PR TITLE
test: add automated guard against README/CLAUDE.md doc drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,6 @@
 
 A Flutter app for Android, iOS, and Web with a rolling character limit: as you type past the limit, the oldest text is dropped. Nothing you write is ever saved.
 
-Kept in sync with `.agents/AGENTS.md`. Update both when either changes.
-
 ## The premise is a constraint, not a feature
 
 Editor text is never persisted, transmitted, or recovered. Only four settings reach storage — `maxCharacters`, `theme`, `fontFamily`, `fontSize` (`lib/services/preferences_service.dart`). Do not add autosave, crash recovery, undo history that survives truncation, or any telemetry carrying content. If a change seems to require it, ask first.
@@ -16,7 +14,7 @@ Editor text is never persisted, transmitted, or recovered. Only four settings re
 
 The ceiling is 25,000 for a reason: `EditableText` does not virtualize. It lays out every glyph in the field, so a higher ceiling makes every keystroke shape the whole buffer through the font pipeline.
 
-`maxFontSize` is 999 because that is the numeric field's range. The slider's own maximum is 144, applied at the slider (`lib/widgets/font_size_sheet.dart`). Do not clamp the constant to 144 — it would shrink a legitimately saved larger size on load.
+`maxFontSize` is 999 because that is the numeric field's range. The slider's own maximum is the separate `maxSliderFontSize` constant, applied at the slider (`lib/widgets/font_size_sheet.dart`). Do not clamp `maxFontSize` down to the slider's range — it would shrink a legitimately saved larger size on load.
 
 ## Truncation operates on grapheme clusters
 
@@ -41,6 +39,7 @@ Flutter is pinned to **3.44.8** in both workflows. A different local version res
 - `test/framework_assumptions_test.dart` is a tripwire, not a unit test. It asserts Flutter defaults the app deliberately does not reimplement — Escape dismissal, arrow-key focus traversal, scroll-into-view. If it fails after an SDK upgrade, restore the behaviour in `main_screen.dart`. Do not delete the test.
 - `test/android_manifest_test.dart` guards `INTERNET` in the release manifest. Debug manifests grant it automatically for hot reload, so removing it breaks uncached Google Fonts downloads in release builds only.
 - `test/widget_test.dart`'s `_pumpMainScreen` builds `AppSettings` from explicit parameters and never calls `loadInto`, so preference-loading behaviour is covered separately in `preferences_service_test.dart`.
+- `test/documentation_consistency_test.dart` fails when a number or fact in `README.md`, `CONTRIBUTING.md`, or `CLAUDE.md` stops matching the constant, enum, or config file it describes — this is what caught the README once advertising a 1,000,000 character limit and a three-theme list after both had changed. A failure means the doc is stale; fix the doc, not the test.
 
 ## Layout
 

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -14,8 +14,9 @@ const int minMaxChars = 1;
 const int maxMaxChars = 25000;
 const double minFontSize = 6;
 const double maxFontSize = 999; // The numeric field's range, not the slider's
-// (6-144). Clamping to the slider's max would shrink a legitimately saved
-// larger size on load.
+// (6-maxSliderFontSize). Clamping to the slider's max would shrink a
+// legitimately saved larger size on load.
+const double maxSliderFontSize = 144;
 
 /// Curated list of 20 Google Fonts, sorted alphabetically.
 const List<String> availableFonts = [

--- a/lib/widgets/font_size_sheet.dart
+++ b/lib/widgets/font_size_sheet.dart
@@ -176,10 +176,10 @@ class _FontSizeSheetState extends State<FontSizeSheet> {
           ),
           const SizedBox(height: 8),
           Slider(
-            value: _size.clamp(6, 144),
-            min: 6,
-            max: 144,
-            divisions: 138,
+            value: _size.clamp(minFontSize, maxSliderFontSize),
+            min: minFontSize,
+            max: maxSliderFontSize,
+            divisions: (maxSliderFontSize - minFontSize).round(),
             label: '${_size.round()}pt',
             onChanged: _onSliderChanged,
           ),
@@ -191,7 +191,7 @@ class _FontSizeSheetState extends State<FontSizeSheet> {
               ),
               Flexible(
                 child: Text(
-                  '144pt',
+                  '${maxSliderFontSize.round()}pt',
                   style: TextStyle(color: colors.textSecondary, fontSize: 12),
                   textAlign: TextAlign.right,
                 ),

--- a/test/documentation_consistency_test.dart
+++ b/test/documentation_consistency_test.dart
@@ -1,0 +1,200 @@
+// Guards documented facts against the code that actually backs them.
+//
+// README.md has twice advertised a number the app no longer enforced -- the
+// character limit stayed at 1,000,000 after the real ceiling dropped to
+// 25,000, and the Themes list named three themes after a fourth and fifth
+// shipped. Both were only caught by a manual audit; this test makes that
+// audit automatic. A failure here means a doc went stale, not that the test
+// is wrong -- fix the doc.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rolling_text/models/app_settings.dart';
+import 'package:rolling_text/theme/app_theme.dart';
+
+/// The repo is checked out with CRLF line endings on Windows but LF on the
+/// Ubuntu CI runner; every regex below assumes LF, so normalize on read.
+String _readFile(String path) =>
+    File(path).readAsStringSync().replaceAll('\r\n', '\n');
+
+String _readmeText() => _readFile('README.md');
+
+/// Same grouping a reader uses: digits from the right, in threes.
+String _withThousandsSeparator(int value) {
+  final digits = value.toString();
+  final buffer = StringBuffer();
+  for (var i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 == 0) buffer.write(',');
+    buffer.write(digits[i]);
+  }
+  return buffer.toString();
+}
+
+/// Text of the bold bullet starting with `- **[label]**` in README.md, up to
+/// the end of that line. Fails with the label name if the bullet is gone or
+/// renamed, rather than silently matching nothing.
+String _readmeBullet(String label) {
+  final pattern = RegExp('- \\*\\*$label\\*\\*[^\\n]*');
+  final match = pattern.firstMatch(_readmeText());
+  expect(
+    match,
+    isNotNull,
+    reason: 'README.md has no "- **$label**" bullet to check against '
+        '$label -- did it get renamed?',
+  );
+  return match!.group(0)!;
+}
+
+void main() {
+  group('README claims that must match app_settings.dart / app_theme.dart', () {
+    test('character limit matches minMaxChars/maxMaxChars', () {
+      final bullet = _readmeBullet('Configurable character limit');
+      expect(
+        bullet,
+        contains(
+          'from $minMaxChars to ${_withThousandsSeparator(maxMaxChars)} characters',
+        ),
+        reason:
+            'The README character limit no longer matches maxMaxChars in '
+            'lib/models/app_settings.dart. This is exactly how the README '
+            'once advertised 1,000,000 after the real ceiling dropped to '
+            '25,000 -- update the README bullet, not this test.',
+      );
+    });
+
+    test('theme list matches AppTheme.values', () {
+      final bullet = _readmeBullet('Themes');
+      final listed = bullet
+          .replaceFirst('- **Themes** - ', '')
+          .split(RegExp(r',\s*(?:and\s+)?|\s+and\s+'))
+          .map((name) => name.trim())
+          .where((name) => name.isNotEmpty)
+          .toSet();
+      final actual = AppTheme.values.map((theme) => theme.label).toSet();
+
+      expect(
+        listed,
+        equals(actual),
+        reason:
+            'The README Themes bullet lists $listed but AppTheme.values in '
+            'lib/theme/app_theme.dart has $actual. This is exactly how the '
+            'README once undercounted the themes after Night and Dark Sepia '
+            'shipped -- update the README bullet, not this test.',
+      );
+    });
+
+    test('font count matches availableFonts.length', () {
+      final bullet = _readmeBullet('Font picker');
+      expect(
+        bullet,
+        contains('${availableFonts.length} curated Google Fonts'),
+        reason:
+            'The README font count no longer matches availableFonts.length '
+            'in lib/models/app_settings.dart.',
+      );
+    });
+
+    test('font size range matches minFontSize/maxFontSize/maxSliderFontSize', () {
+      final bullet = _readmeBullet('Adjustable font size');
+      expect(
+        bullet,
+        contains(
+          '${minFontSize.round()}pt to ${maxFontSize.round()}pt',
+        ),
+        reason:
+            'The numeric field range in the README no longer matches '
+            'minFontSize/maxFontSize in lib/models/app_settings.dart.',
+      );
+      expect(
+        bullet,
+        contains(
+          'slider for ${minFontSize.round()}pt to ${maxSliderFontSize.round()}pt',
+        ),
+        reason:
+            'The slider range in the README no longer matches '
+            'minFontSize/maxSliderFontSize in lib/models/app_settings.dart.',
+      );
+    });
+  });
+
+  group('Toolchain claims that must match the workflows and pubspec', () {
+    String flutterVersionFrom(String workflowPath) {
+      final contents = _readFile(workflowPath);
+      final match = RegExp(r'flutter-version:\s*(\S+)').firstMatch(contents);
+      expect(
+        match,
+        isNotNull,
+        reason: '$workflowPath has no flutter-version: line to check.',
+      );
+      return match!.group(1)!;
+    }
+
+    test('both workflows pin the same Flutter version', () {
+      final buildRelease =
+          flutterVersionFrom('.github/workflows/build-release.yml');
+      final deployWeb = flutterVersionFrom('.github/workflows/deploy-web.yml');
+
+      expect(
+        buildRelease,
+        equals(deployWeb),
+        reason:
+            'build-release.yml pins Flutter $buildRelease but deploy-web.yml '
+            'pins $deployWeb. A local Flutter matching only one of them will '
+            'resolve pubspec.lock differently than the workflow that '
+            'disagrees.',
+      );
+    });
+
+    test('README, CONTRIBUTING.md, and CLAUDE.md all state the pinned Flutter version', () {
+      final version =
+          flutterVersionFrom('.github/workflows/build-release.yml');
+
+      for (final path in ['README.md', 'CONTRIBUTING.md', 'CLAUDE.md']) {
+        expect(
+          _readFile(path),
+          contains(version),
+          reason:
+              '$path does not mention Flutter $version, the version pinned '
+              'in build-release.yml. This is the class of drift that once '
+              'left "Flutter 3.x" in the README next to a hard 3.44.8 pin.',
+        );
+      }
+    });
+
+    test('README dependency list matches pubspec.yaml dependencies', () {
+      final pubspec = _readFile('pubspec.yaml');
+      // Captures indented (or blank) lines directly under "dependencies:",
+      // stopping at the next line that starts a new top-level key.
+      final depsBlock = RegExp(
+        r'\ndependencies:\n((?:  .*\n|\n)*)',
+      ).firstMatch(pubspec);
+      expect(
+        depsBlock,
+        isNotNull,
+        reason: 'pubspec.yaml has no dependencies: block to check against.',
+      );
+
+      final pubspecDeps = RegExp(r'^\s{2}([a-zA-Z0-9_]+):', multiLine: true)
+          .allMatches(depsBlock!.group(1)!)
+          .map((m) => m.group(1)!)
+          .where((name) => name != 'flutter')
+          .toSet();
+
+      final bullet = _readmeBullet('Dependencies');
+      final readmeDeps = RegExp(r'`([a-zA-Z0-9_]+)`')
+          .allMatches(bullet)
+          .map((m) => m.group(1)!)
+          .toSet();
+
+      expect(
+        readmeDeps,
+        equals(pubspecDeps),
+        reason:
+            'README Dependencies bullet lists $readmeDeps but pubspec.yaml '
+            'dependencies: has $pubspecDeps. Adding or removing a package '
+            'should update both.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #52

## What changed

PR #51 fixed two stale README facts that had drifted from the code behind them — same bug pattern twice, one instance found only by accident in unrelated test output. This adds an automated check so the pattern fails CI instead of waiting for the next manual audit.

**`test/documentation_consistency_test.dart`** asserts documented facts against their actual source of truth:

- Character limit against `minMaxChars`/`maxMaxChars`
- Theme list against `AppTheme.values` (compared as a set, both directions, so a removed theme can't linger in the doc)
- Font count against `availableFonts.length`
- Font size range (numeric field and slider) against `minFontSize`/`maxFontSize`/`maxSliderFontSize`
- Flutter version agreement between `build-release.yml` and `deploy-web.yml`, and that `README.md`, `CONTRIBUTING.md`, and `CLAUDE.md` all state it
- Dependency list against `pubspec.yaml`'s `dependencies:` block (both directions)

**`lib/models/app_settings.dart` / `lib/widgets/font_size_sheet.dart`** — the slider's maximum was a bare literal `144`, repeated three times (value clamp, `max`, and the scale label), with `divisions: 138` silently encoding `144 - 6`. It's now `maxSliderFontSize`, a named constant alongside `minFontSize`/`maxFontSize`, with `divisions` derived from it. This was the only limit in the app not already living in one place, and the reason the slider claim wasn't testable before this. Behavior is unchanged.

**`CLAUDE.md`** drops the line pointing at `.agents/AGENTS.md`, which is gitignored and not present in a fresh clone, and gains a note describing the new test.

## Notes

Two things worth knowing if this test ever needs touching:

- All the files it reads check out CRLF on Windows but will be LF on the `ubuntu-latest` CI runner, so every read goes through a normalizing helper rather than raw `readAsStringSync()`.
- `pubspec.yaml`'s `dependencies:` block has no delimiter before the next top-level key besides that key itself, so the extraction regex matches indented/blank lines rather than looking for a fixed terminator.

No `CHANGELOG.md` entry — this is test/tooling only, not user-facing, and the version stays untouched outside a release per `CONTRIBUTING.md`.

## Testing

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 94 tests pass (87 existing + 7 new)
- [x] `flutter test test/widget_test.dart` — all font-size sheet cases pass unchanged after the constant refactor
- [x] Proved the guard actually fails, one case at a time, each reverted immediately after: bumped `maxMaxChars`, renamed a theme label, dropped a font from `availableFonts`, mismatched `flutter-version` between the two workflows, and added a dependency to `pubspec.yaml` not reflected in the README. Every case failed with a message naming the file to fix; working tree confirmed clean afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)