### PR TITLE
docs: split README into a docs/ directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Editor text is never persisted, transmitted, or recovered. Only four settings re
 
 ## Limits live in exactly one place
 
-`lib/models/app_settings.dart` declares `minMaxChars`, `maxMaxChars`, `minFontSize`, and `maxFontSize`. Sheets and validators must read those constants — never hardcode the numbers, and never restate them in the README without checking. Duplicating the limit is what caused the 0.5.6 bug, where the Character Limit sheet still advertised 1,000,000 after the ceiling dropped to 25,000.
+`lib/models/app_settings.dart` declares `minMaxChars`, `maxMaxChars`, `minFontSize`, and `maxFontSize`. Sheets and validators must read those constants — never hardcode the numbers, and never restate them in `docs/user-guide.md` without checking. Duplicating the limit is what caused the 0.5.6 bug, where the Character Limit sheet still advertised 1,000,000 after the ceiling dropped to 25,000.
 
 The ceiling is 25,000 for a reason: `EditableText` does not virtualize. It lays out every glyph in the field, so a higher ceiling makes every keystroke shape the whole buffer through the font pipeline.
 
@@ -39,7 +39,7 @@ Flutter is pinned to **3.44.8** in both workflows. A different local version res
 - `test/framework_assumptions_test.dart` is a tripwire, not a unit test. It asserts Flutter defaults the app deliberately does not reimplement — Escape dismissal, arrow-key focus traversal, scroll-into-view. If it fails after an SDK upgrade, restore the behaviour in `main_screen.dart`. Do not delete the test.
 - `test/android_manifest_test.dart` guards `INTERNET` in the release manifest. Debug manifests grant it automatically for hot reload, so removing it breaks uncached Google Fonts downloads in release builds only.
 - `test/widget_test.dart`'s `_pumpMainScreen` builds `AppSettings` from explicit parameters and never calls `loadInto`, so preference-loading behaviour is covered separately in `preferences_service_test.dart`.
-- `test/documentation_consistency_test.dart` fails when a number or fact in `README.md`, `CONTRIBUTING.md`, or `CLAUDE.md` stops matching the constant, enum, or config file it describes — this is what caught the README once advertising a 1,000,000 character limit and a three-theme list after both had changed. A failure means the doc is stale; fix the doc, not the test.
+- `test/documentation_consistency_test.dart` fails when a number or fact in `docs/user-guide.md`, `docs/releasing.md`, `README.md`, `CONTRIBUTING.md`, or `CLAUDE.md` stops matching the constant, enum, or config file it describes — this is what caught the feature list once advertising a 1,000,000 character limit and a three-theme list after both had changed. The guarded feature bullets live in `docs/user-guide.md`; the `Dependencies` bullet is in `README.md`. A failure means the doc is stale; fix the doc, not the test.
 
 ## Layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Add an entry to the `## [Unreleased]` section of [`CHANGELOG.md`](CHANGELOG.md).
 
 **Keep every bullet on one unbroken line.** GitHub's release renderer preserves mid-bullet newlines as visible line breaks instead of reflowing them, so a hard-wrapped bullet publishes as broken release notes.
 
-Do not bump the version in `pubspec.yaml` in a feature PR. Versioning happens at release time, where the git tag, the `pubspec.yaml` version, and a matching `CHANGELOG.md` section all have to agree or the release workflow fails. See [Releasing](README.md#releasing).
+Do not bump the version in `pubspec.yaml` in a feature PR. Versioning happens at release time, where the git tag, the `pubspec.yaml` version, and a matching `CHANGELOG.md` section all have to agree or the release workflow fails. See [Releasing](docs/releasing.md).
 
 ## Editing workflows
 

--- a/README.md
+++ b/README.md
@@ -7,52 +7,12 @@
 
 A simple app for Android, iOS, and Web that gives you a place to write down your thoughts without keeping them. As you type, older text quietly disappears. Nothing is saved. Nothing is stored.
 
-## About
+## Documentation
 
-We all carry thoughts we wish we didn't. The worries that keep us up at night. The harsh things we say to ourselves. The moments we replay over and over even though we can't change them. That's just part of being human, and it can be really heavy.
-
-Rolling Text is a simple place to set those thoughts down. As you type, your words quietly disappear. Nothing is saved. Nothing is stored. You don't have to organize your feelings or make them make sense. Just let them out, and let them go.
-
-There's something powerful about putting a difficult thought into words and then watching it leave. You're not ignoring what you feel. You're giving yourself permission to feel it, express it, and release it.
-
-And it turns out, science agrees.
-
-**Writing down your thoughts and letting them go actually works.** Researchers found that when people wrote down negative thoughts and then discarded them, even digitally by dragging them to the recycle bin on a computer, those thoughts lost their grip. They had significantly less influence on emotions and self-perception afterward. It wasn't just the writing that helped. It was the act of letting go. (Briñol, Petty, Gascó & Horcajo, 2012, *Psychological Science*)
-
-**Putting your feelings into words is a form of healing.** Over four decades of research on expressive writing, pioneered by psychologist James Pennebaker, has shown that writing about what's bothering us, even for just a few minutes, can meaningfully improve both our emotional and physical well-being. You don't have to write well. You just have to write honestly. (Pennebaker, 2018, *Perspectives on Psychological Science*)
-
-**You are not your thoughts.** In Acceptance and Commitment Therapy (ACT), a practice called cognitive defusion helps people step back and see their thoughts for what they really are: passing mental events, not permanent truths. Research shows that this kind of distance reduces both the pain and the believability of harsh, self-critical thoughts more effectively than trying to distract yourself or push them away. (Masuda et al., 2004, *Behavior Therapy*; Larsson et al., 2016, *Behavior Modification*)
-
-**Letting go isn't weakness. It's a skill.** A 2023 study from the University of Cambridge found that people who practiced actively releasing unwanted thoughts experienced less anxiety, less depression, and fewer intrusive negative emotions. This was true even for those living with clinical mental health conditions. Sometimes the bravest thing you can do is choose not to hold on. (Mamat et al., 2023, *Science Advances*)
-
-Rolling Text isn't therapy, and it's not a replacement for professional support. If you're struggling, please reach out to someone who can help. But for the everyday weight of being human, for the thoughts that just need somewhere to go, this is a quiet place to let them pass through.
-
-## How It Works
-
-The app maintains a rolling character limit. When you type past the limit, the oldest text is automatically removed from the beginning. Your cursor keeps its place in the text that survives, so you can keep typing.
-
-A character here means an extended grapheme cluster, which is what a reader thinks of as one character. A flag emoji or an accented letter counts once and is removed whole, rather than being cut apart into the code points it is built from.
-
-```
-Limit: 10 characters
-
-Type: "Hello Wor"  -> 9 chars, OK
-Type: "Hello Worl" -> 10 chars, at limit
-Type: "Hello World" -> "ello World" ('H' removed automatically)
-```
-
-Lowering the limit below what you have already written removes the oldest characters immediately, without asking. Like everything else in Rolling Text, that text is gone rather than recoverable.
-
-## Features
-
-- **Configurable character limit** - Set anywhere from 1 to 25,000 characters
-- **Themes** - Light, Dark, Sepia, Night, and Dark Sepia
-- **Font picker** - Choose from 20 curated Google Fonts, or Source Code Pro as the default. Uncached fonts require an internet connection on first use.
-- **Adjustable font size** - Type any size from 6pt to 999pt, or drag the slider for 6pt to 144pt
-- **Keyboard operation** - Every settings sheet works without a mouse: arrow keys move between themes and fonts, Enter applies, Escape closes, and arrow or page keys scroll the About text. Focus returns to the editor when a sheet closes, when you tap elsewhere in the app, or when you switch back to the app after leaving it.
-- **Settings persistence** - Character limit, theme, font, and font size are saved between sessions. Text is never saved. Saved values are validated on load and fall back to defaults if storage is corrupt or out of range. A setting that fails to save still applies for the session, with a warning that it won't be remembered.
-- **Private by default on Android** - The editor opts out of IME personalized learning, so what you type is not added to your keyboard's dictionary or typing history
-- **Unicode and emoji support** - Truncation removes whole extended grapheme clusters, so accented letters, flag emoji, skin-tone modifiers, and ZWJ sequences are never split in half at the boundary
+- [User guide](docs/user-guide.md) — how the rolling limit works, and every setting
+- [Why this works](docs/about.md) — the premise, and the research behind it
+- [Contributing](CONTRIBUTING.md) — setup, tests, and commit conventions
+- [Releasing](docs/releasing.md) — release process and CI workflows
 
 ## Installation
 
@@ -98,39 +58,6 @@ flutter build web                        # Web
 ### APK download
 
 Download the latest APK from the [Releases](https://github.com/XeroIP/rolling-text/releases) page.
-
-## Releasing
-
-Releases are cut from tags. [`CHANGELOG.md`](CHANGELOG.md) is the single source of truth for what a release says.
-
-1. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`. Keep every bullet on one unbroken line — GitHub's release renderer turns mid-bullet newlines into visible line breaks instead of reflowing them.
-2. Set the matching version in `pubspec.yaml`, incrementing the build number after the `+` as well. Android refuses to install an APK whose build number is not higher than the installed one.
-3. Tag and push:
-
-    ```bash
-    git tag v0.5.0
-    git push origin v0.5.0
-    ```
-
-The `Build and release` workflow then runs the tests, builds signed release and debug APKs, and publishes a GitHub release whose notes are that CHANGELOG section followed by the auto-generated list of merged pull requests, with both APKs attached.
-
-It fails the release rather than publishing something wrong if the tag does not match `pubspec.yaml`, or if `CHANGELOG.md` has no section for that version.
-
-To build APKs without releasing, run the workflow manually from the Actions tab (`Actions > Build and release > Run workflow`); the APKs are uploaded as build artifacts instead.
-
-Tagging only publishes the APKs. The web app is published separately, as described below, so a release tag is not what updates the site.
-
-## Continuous integration
-
-Three workflows run in `.github/workflows/`, all pinned to Flutter 3.44.8:
-
-| Workflow | Trigger | What it does |
-| --- | --- | --- |
-| `build-release.yml` | Tag `v*.*.*`, or manual | Tests, builds signed APKs, publishes the GitHub release. See [Releasing](#releasing). |
-| `deploy-web.yml` | Every push to `main` | Builds `flutter build web --release --base-href /rolling-text/` and publishes it to GitHub Pages. |
-| `policy-pinned-actions.yml` | Push to `main`, and any PR touching `.github/workflows/**` | Fails if a third-party action is referenced by tag instead of a full 40-character commit SHA. |
-
-Because `deploy-web.yml` fires on every push to `main`, whatever is on `main` is what https://xeroip.github.io/rolling-text/ serves. There is no separate step to publish the web app.
 
 ## Technical Details
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,25 @@
+# Why this works
+
+We all carry thoughts we wish we didn't. The worries that keep us up at night. The harsh things we say to ourselves. The moments we replay over and over even though we can't change them. That's just part of being human, and it can be really heavy.
+
+Rolling Text is a simple place to set those thoughts down. As you type, your words quietly disappear. Nothing is saved. Nothing is stored. You don't have to organize your feelings or make them make sense. Just let them out, and let them go.
+
+There's something powerful about putting a difficult thought into words and then watching it leave. You're not ignoring what you feel. You're giving yourself permission to feel it, express it, and release it.
+
+And it turns out, science agrees.
+
+**Writing down your thoughts and letting them go actually works.** Researchers found that when people wrote down negative thoughts and then discarded them, even digitally by dragging them to the recycle bin on a computer, those thoughts lost their grip. They had significantly less influence on emotions and self-perception afterward. It wasn't just the writing that helped. It was the act of letting go. (Briñol, Petty, Gascó & Horcajo, 2012, *Psychological Science*)
+
+**Putting your feelings into words is a form of healing.** Over four decades of research on expressive writing, pioneered by psychologist James Pennebaker, has shown that writing about what's bothering us, even for just a few minutes, can meaningfully improve both our emotional and physical well-being. You don't have to write well. You just have to write honestly. (Pennebaker, 2018, *Perspectives on Psychological Science*)
+
+**You are not your thoughts.** In Acceptance and Commitment Therapy (ACT), a practice called cognitive defusion helps people step back and see their thoughts for what they really are: passing mental events, not permanent truths. Research shows that this kind of distance reduces both the pain and the believability of harsh, self-critical thoughts more effectively than trying to distract yourself or push them away. (Masuda et al., 2004, *Behavior Therapy*; Larsson et al., 2016, *Behavior Modification*)
+
+**Letting go isn't weakness. It's a skill.** A 2023 study from the University of Cambridge found that people who practiced actively releasing unwanted thoughts experienced less anxiety, less depression, and fewer intrusive negative emotions. This was true even for those living with clinical mental health conditions. Sometimes the bravest thing you can do is choose not to hold on. (Mamat et al., 2023, *Science Advances*)
+
+Rolling Text isn't therapy, and it's not a replacement for professional support. If you're struggling, please reach out to someone who can help. But for the everyday weight of being human, for the thoughts that just need somewhere to go, this is a quiet place to let them pass through.
+
+---
+
+This text is also shown in the app itself, through the About sheet in `lib/screens/main_screen.dart`. The two copies are maintained independently — if you edit one, edit the other. Do not add a third copy to the README.
+
+See the [user guide](user-guide.md) for how the app actually behaves.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,36 @@
+# Releasing and CI
+
+Maintainer documentation. For contributor setup and commit conventions, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Releasing
+
+Releases are cut from tags. [`CHANGELOG.md`](../CHANGELOG.md) is the single source of truth for what a release says.
+
+1. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`. Keep every bullet on one unbroken line — GitHub's release renderer turns mid-bullet newlines into visible line breaks instead of reflowing them.
+2. Set the matching version in `pubspec.yaml`, incrementing the build number after the `+` as well. Android refuses to install an APK whose build number is not higher than the installed one.
+3. Tag and push:
+
+    ```bash
+    git tag v0.5.0
+    git push origin v0.5.0
+    ```
+
+The `Build and release` workflow then runs the tests, builds signed release and debug APKs, and publishes a GitHub release whose notes are that CHANGELOG section followed by the auto-generated list of merged pull requests, with both APKs attached.
+
+It fails the release rather than publishing something wrong if the tag does not match `pubspec.yaml`, or if `CHANGELOG.md` has no section for that version.
+
+To build APKs without releasing, run the workflow manually from the Actions tab (`Actions > Build and release > Run workflow`); the APKs are uploaded as build artifacts instead.
+
+Tagging only publishes the APKs. The web app is published separately, as described below, so a release tag is not what updates the site.
+
+## Continuous integration
+
+Three workflows run in `.github/workflows/`, all pinned to Flutter 3.44.8:
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `build-release.yml` | Tag `v*.*.*`, or manual | Tests, builds signed APKs, publishes the GitHub release. See [Releasing](#releasing). |
+| `deploy-web.yml` | Every push to `main` | Builds `flutter build web --release --base-href /rolling-text/` and publishes it to GitHub Pages. |
+| `policy-pinned-actions.yml` | Push to `main`, and any PR touching `.github/workflows/**` | Fails if a third-party action is referenced by tag instead of a full 40-character commit SHA. |
+
+Because `deploy-web.yml` fires on every push to `main`, whatever is on `main` is what https://xeroip.github.io/rolling-text/ serves. There is no separate step to publish the web app.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,30 @@
+# Rolling Text — user guide
+
+Everything the app does, and how each setting behaves. For why the app works the way it does, see [Why this works](about.md).
+
+## How It Works
+
+The app maintains a rolling character limit. When you type past the limit, the oldest text is automatically removed from the beginning. Your cursor keeps its place in the text that survives, so you can keep typing.
+
+A character here means an extended grapheme cluster, which is what a reader thinks of as one character. A flag emoji or an accented letter counts once and is removed whole, rather than being cut apart into the code points it is built from.
+
+```
+Limit: 10 characters
+
+Type: "Hello Wor"  -> 9 chars, OK
+Type: "Hello Worl" -> 10 chars, at limit
+Type: "Hello World" -> "ello World" ('H' removed automatically)
+```
+
+Lowering the limit below what you have already written removes the oldest characters immediately, without asking. Like everything else in Rolling Text, that text is gone rather than recoverable.
+
+## Features
+
+- **Configurable character limit** - Set anywhere from 1 to 25,000 characters
+- **Themes** - Light, Dark, Sepia, Night, and Dark Sepia
+- **Font picker** - Choose from 20 curated Google Fonts, or Source Code Pro as the default. Uncached fonts require an internet connection on first use.
+- **Adjustable font size** - Type any size from 6pt to 999pt, or drag the slider for 6pt to 144pt
+- **Keyboard operation** - Every settings sheet works without a mouse: arrow keys move between themes and fonts, Enter applies, Escape closes, and arrow or page keys scroll the About text. Focus returns to the editor when a sheet closes, when you tap elsewhere in the app, or when you switch back to the app after leaving it.
+- **Settings persistence** - Character limit, theme, font, and font size are saved between sessions. Text is never saved. Saved values are validated on load and fall back to defaults if storage is corrupt or out of range. A setting that fails to save still applies for the session, with a warning that it won't be remembered.
+- **Private by default on Android** - The editor opts out of IME personalized learning, so what you type is not added to your keyboard's dictionary or typing history
+- **Unicode and emoji support** - Truncation removes whole extended grapheme clusters, so accented letters, flag emoji, skin-tone modifiers, and ZWJ sequences are never split in half at the boundary

--- a/test/documentation_consistency_test.dart
+++ b/test/documentation_consistency_test.dart
@@ -1,11 +1,12 @@
 // Guards documented facts against the code that actually backs them.
 //
-// README.md has twice advertised a number the app no longer enforced -- the
-// character limit stayed at 1,000,000 after the real ceiling dropped to
-// 25,000, and the Themes list named three themes after a fourth and fifth
-// shipped. Both were only caught by a manual audit; this test makes that
-// audit automatic. A failure here means a doc went stale, not that the test
-// is wrong -- fix the doc.
+// The feature list -- now docs/user-guide.md, previously README.md -- has
+// twice advertised a number the app no longer enforced: the character limit
+// stayed at 1,000,000 after the real ceiling dropped to 25,000, and the
+// Themes list named three themes after a fourth and fifth shipped. Both were
+// only caught by a manual audit; this test makes that audit automatic. A
+// failure here means a doc went stale, not that the test is wrong -- fix the
+// doc.
 
 import 'dart:io';
 
@@ -18,7 +19,8 @@ import 'package:rolling_text/theme/app_theme.dart';
 String _readFile(String path) =>
     File(path).readAsStringSync().replaceAll('\r\n', '\n');
 
-String _readmeText() => _readFile('README.md');
+/// The user-facing feature list. The bullets checked below live here.
+const _userGuide = 'docs/user-guide.md';
 
 /// Same grouping a reader uses: digits from the right, in threes.
 String _withThousandsSeparator(int value) {
@@ -31,40 +33,42 @@ String _withThousandsSeparator(int value) {
   return buffer.toString();
 }
 
-/// Text of the bold bullet starting with `- **[label]**` in README.md, up to
-/// the end of that line. Fails with the label name if the bullet is gone or
-/// renamed, rather than silently matching nothing.
-String _readmeBullet(String label) {
+/// Text of the bold bullet starting with `- **[label]**` in [path], up to the
+/// end of that line. Fails with the label name if the bullet is gone or
+/// renamed, rather than silently matching nothing -- which is also what keeps
+/// a wrong [path] from passing vacuously.
+String _bullet(String path, String label) {
   final pattern = RegExp('- \\*\\*$label\\*\\*[^\\n]*');
-  final match = pattern.firstMatch(_readmeText());
+  final match = pattern.firstMatch(_readFile(path));
   expect(
     match,
     isNotNull,
-    reason: 'README.md has no "- **$label**" bullet to check against '
-        '$label -- did it get renamed?',
+    reason: '$path has no "- **$label**" bullet to check against '
+        '$label -- did it get renamed or moved to another file?',
   );
   return match!.group(0)!;
 }
 
 void main() {
-  group('README claims that must match app_settings.dart / app_theme.dart', () {
+  group('Documented claims that must match app_settings.dart / app_theme.dart',
+      () {
     test('character limit matches minMaxChars/maxMaxChars', () {
-      final bullet = _readmeBullet('Configurable character limit');
+      final bullet = _bullet(_userGuide, 'Configurable character limit');
       expect(
         bullet,
         contains(
           'from $minMaxChars to ${_withThousandsSeparator(maxMaxChars)} characters',
         ),
         reason:
-            'The README character limit no longer matches maxMaxChars in '
-            'lib/models/app_settings.dart. This is exactly how the README '
+            'The $_userGuide character limit no longer matches maxMaxChars in '
+            'lib/models/app_settings.dart. This is exactly how the docs '
             'once advertised 1,000,000 after the real ceiling dropped to '
-            '25,000 -- update the README bullet, not this test.',
+            '25,000 -- update the user guide bullet, not this test.',
       );
     });
 
     test('theme list matches AppTheme.values', () {
-      final bullet = _readmeBullet('Themes');
+      final bullet = _bullet(_userGuide, 'Themes');
       final listed = bullet
           .replaceFirst('- **Themes** - ', '')
           .split(RegExp(r',\s*(?:and\s+)?|\s+and\s+'))
@@ -77,33 +81,33 @@ void main() {
         listed,
         equals(actual),
         reason:
-            'The README Themes bullet lists $listed but AppTheme.values in '
-            'lib/theme/app_theme.dart has $actual. This is exactly how the '
-            'README once undercounted the themes after Night and Dark Sepia '
-            'shipped -- update the README bullet, not this test.',
+            'The $_userGuide Themes bullet lists $listed but AppTheme.values '
+            'in lib/theme/app_theme.dart has $actual. This is exactly how the '
+            'docs once undercounted the themes after Night and Dark Sepia '
+            'shipped -- update the user guide bullet, not this test.',
       );
     });
 
     test('font count matches availableFonts.length', () {
-      final bullet = _readmeBullet('Font picker');
+      final bullet = _bullet(_userGuide, 'Font picker');
       expect(
         bullet,
         contains('${availableFonts.length} curated Google Fonts'),
         reason:
-            'The README font count no longer matches availableFonts.length '
-            'in lib/models/app_settings.dart.',
+            'The $_userGuide font count no longer matches '
+            'availableFonts.length in lib/models/app_settings.dart.',
       );
     });
 
     test('font size range matches minFontSize/maxFontSize/maxSliderFontSize', () {
-      final bullet = _readmeBullet('Adjustable font size');
+      final bullet = _bullet(_userGuide, 'Adjustable font size');
       expect(
         bullet,
         contains(
           '${minFontSize.round()}pt to ${maxFontSize.round()}pt',
         ),
         reason:
-            'The numeric field range in the README no longer matches '
+            'The numeric field range in $_userGuide no longer matches '
             'minFontSize/maxFontSize in lib/models/app_settings.dart.',
       );
       expect(
@@ -112,7 +116,7 @@ void main() {
           'slider for ${minFontSize.round()}pt to ${maxSliderFontSize.round()}pt',
         ),
         reason:
-            'The slider range in the README no longer matches '
+            'The slider range in $_userGuide no longer matches '
             'minFontSize/maxSliderFontSize in lib/models/app_settings.dart.',
       );
     });
@@ -146,11 +150,17 @@ void main() {
       );
     });
 
-    test('README, CONTRIBUTING.md, and CLAUDE.md all state the pinned Flutter version', () {
+    test('every doc that names the toolchain states the pinned Flutter version',
+        () {
       final version =
           flutterVersionFrom('.github/workflows/build-release.yml');
 
-      for (final path in ['README.md', 'CONTRIBUTING.md', 'CLAUDE.md']) {
+      for (final path in [
+        'README.md',
+        'CONTRIBUTING.md',
+        'CLAUDE.md',
+        'docs/releasing.md',
+      ]) {
         expect(
           _readFile(path),
           contains(version),
@@ -181,7 +191,7 @@ void main() {
           .where((name) => name != 'flutter')
           .toSet();
 
-      final bullet = _readmeBullet('Dependencies');
+      final bullet = _bullet('README.md', 'Dependencies');
       final readmeDeps = RegExp(r'`([a-zA-Z0-9_]+)`')
           .allMatches(bullet)
           .map((m) => m.group(1)!)


### PR DESCRIPTION
Splits the 158-line README into a `docs/` directory organised by audience. No user-facing behaviour changes, so no CHANGELOG entry.

## Why

The README carried four unrelated audiences at once — a prospective user, a reader of the research behind the premise, a developer building from source, and a maintainer cutting a release. Seventeen lines of About prose ran before a reader reached "How It Works".

## What moved

| File | Audience | Content |
| --- | --- | --- |
| `README.md` | First 30 seconds | Badges, pitch, doc links, install, stack, license (158 → 84 lines) |
| `docs/about.md` | Curious user | The premise and the research narrative |
| `docs/user-guide.md` | User | How truncation works, and the feature list |
| `docs/releasing.md` | Maintainer | Release process and the three CI workflows |

Prose moved verbatim — this is a move, not an edit pass.

## The test that had to move with it

`documentation_consistency_test.dart` parsed the README's bold feature bullets to catch doc drift. Those bullets are now in `docs/user-guide.md`, so:

- `_readmeBullet(label)` becomes `_bullet(path, label)`.
- The four guarded bullets are read from `docs/user-guide.md`; `Dependencies` still comes from `README.md`, where Technical Details stays.
- `docs/releasing.md` joins the list of files that must state the pinned Flutter version.
- Failure messages name the file to fix.

## Verification

- `flutter analyze` — no issues.
- `flutter test` — 94/94 passing.
- No `pubspec.lock` churn.
- **Confirmed the guard still bites**: dropped two themes from the user-guide bullet and the test failed naming `docs/user-guide.md`, then reverted. A wrong path would find no bullets, and the existing `expect(match, isNotNull)` is what turns that into a loud failure instead of a vacuous pass.
- All relative link targets checked to exist.

## Flagged, not fixed

- `.agents/AGENTS.md` is gitignored (`.gitignore:72`), so it cannot be kept in sync through git. There is also an untracked root `AGENTS.md` with overlapping content, predating this branch.
- `.agents/AGENTS.md:19` still says the font-size slider max is a hardcoded 144, where `CLAUDE.md:19` names the `maxSliderFontSize` constant. Pre-existing drift, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
