### PR TITLE
chore: add AGENTS.md as a pointer to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Guidelines
+
+See [CLAUDE.md](CLAUDE.md) for repository instructions — project structure, build and test commands, coding style, testing guidelines, commit and PR conventions, and privacy/security/release rules.


### PR DESCRIPTION
Closes #55.

Three agent-instruction files existed with no mechanism keeping them consistent: `CLAUDE.md` (tracked, current), `.agents/AGENTS.md` (gitignored, already drifted, Antigravity's), and root `AGENTS.md` (untracked, a parallel rewrite for Codex).

## What changed

- `.agents/AGENTS.md` removed locally — it was gitignored, so git never tracked it and this PR carries no diff for it.
- Root `AGENTS.md` added as a **pointer** to `CLAUDE.md` rather than a parallel copy.

## Why a pointer instead of a synced copy

Confirmed empirically before committing to this approach: a scratch `AGENTS.md` containing nothing but a markdown link to `CLAUDE.md`, with a fact that existed nowhere else, was enough for `codex exec` to read `CLAUDE.md` unprompted and answer correctly — confirmed at the tool-call level (the run log showed it executing `Get-Content` on `CLAUDE.md`), not just from the answer.

A pointer removes the drift surface entirely rather than requiring a test to guard two prose files against each other — there's now exactly one file with real content.

## Verification

- `flutter analyze` / `flutter test` unaffected — no `lib/` or `test/` changes.
- `documentation_consistency_test.dart` doesn't reference `AGENTS.md`, so no test changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)